### PR TITLE
fix: rewrite cv copy to sound like a human

### DIFF
--- a/src/components/cv.mdx
+++ b/src/components/cv.mdx
@@ -115,7 +115,7 @@ Git, SVN, BDD, TDD, Vagrant, Nginx, Apache, Agile, JIRA, Trello, Linux
 
 ## Who is James?
 
-Outside of work: photography (events, portrait, street, travel), cycling (fixed gear mostly, some gravel). Used to put on shows and DJ club nights in Brighton. I follow current affairs and keep up with what's happening in tech, politics, and science.
+I don't see programming and computers as simply a job, but part of who I am. I think the world is going through very interesting times and it will be passionate programmers and thinkers that will play an important part in shaping it. My current hobbies are photography (events, portrait, street, travel), and I'm an avid cyclist (mainly fixed, but also gravel). When I lived in Brighton I often helped out with putting on shows and DJing at club nights. I enjoy going out with friends and finding new bands or other weird and wonderful things to do. I am a keen follower of current affairs, especially from a technical standpoint, and think a lot about the world and am interested by new developments politically and scientifically.
 
 ## Less Recent Work
 

--- a/src/components/cv.mdx
+++ b/src/components/cv.mdx
@@ -5,13 +5,11 @@ senior full stack engineer
 **e-mail:** [jc@blit.cc](mailto:jc@blit.cc)<br/>
 **github:** [@radiosilence](https://github.com/radiosilence)
 
-Experienced polyglot engineer with a huge breadth and depth of knowledge and understanding, working in multiple languages across a wide range of commercial frontend, backend, devops, and embedded contexts. Lives for problem solving and optimising, and thrives in the challenges of the London tech startup scene.
+Polyglot engineer — frontend, backend, devops, embedded, whatever needs doing. I pick things up fast and ship them. Fifteen years building things across the London startup scene and beyond.
 
-Communicating complex technical solutions to stakeholders and fellow engineers in a way they can relate to is key to my approach—if people can't understand what's happening, the most appropriate solution is unlikely to be reached.
+I care about clear communication. If people can't follow what's going on technically, you end up building the wrong thing.
 
-Passionate about having reproducible, declarative infrastructure using CI/CD and IaC (GitOps).
-
-As a natural creative, what drives me is a job where I wake up every day and build something interesting.
+Big on reproducible infrastructure — CI/CD, IaC, GitOps. If it can't be rebuilt from scratch, it's not done.
 
 ## Recent Work
 
@@ -24,72 +22,66 @@ As a natural creative, what drives me is a job where I wake up every day and bui
 
 _Key Skills: GraphQL, Next.js, Elixir, TypeScript, GitHub Actions, CSS, gRPC, Protobufs, AI, Docker_
 
-- Developing features from backend Elixir microservices to gateway (GraphQL/Yoga) to frontend (TypeScript/Next.js) across consumer and business applications.
-- Building complex resolvers pulling in data sources from a variety of internal APIs and microservices.
-- Instrumental in delivering the customer loyalty platform – the largest B2C feature release to date.
-- Managing requirements in a fast-paced environment and taking initiative to deliver high-quality work within tight deadlines.
-- Coming up with creative solutions to problems unique to global marketplace scale and architecture.
-- Providing technical leadership and mentorship to junior and mid-level engineers when they face complex challenges.
-- Getting involved with projects at product-level to give context required for technical decision making.
+- Full-stack across Elixir microservices → GraphQL/Yoga gateway → Next.js/TypeScript frontends, both consumer and business-facing.
+- Built out the customer loyalty platform — biggest B2C feature release the company had done.
+- Wrangling data from a mess of internal APIs into coherent GraphQL resolvers.
+- Helping junior and mid-level engineers when they hit walls.
+- Getting stuck into product-level discussions so technical decisions actually make sense.
 
 ### Senior Full Stack Engineer, [Apolitical](https://apolitical.co) <small>Apr 2024–Aug 2024</small>
 
 _Key Skills: Next.js, NestJS, React, Kubernetes, SCSS, TypeScript, JavaScript, Vite, Express_
 
-- Developed new features using Next.js and TypeScript, facilitating the migration to a new architecture.
-- Created APIs and endpoints using NestJS.
-- Managed legacy JS code in React frontends and Express microservices.
-- Resolved issues and debugged performance of services deployed on Kubernetes.
-- Enhanced and expanded existing GitHub Actions CI/CD pipelines.
+- Built features in Next.js/TypeScript as part of a migration to their new architecture.
+- Wrote APIs in NestJS, maintained legacy React/Express services.
+- Debugged K8s performance issues, improved GitHub Actions CI/CD pipelines.
 
 ### Senior Cloud Native Engineer, [EngineerBetter](https://container-solutions.com) <small>Jan 2022–Jan 2024</small>
 
 _Key Skills: AWS, Docker, Kubernetes, Terraform, Azure, Concourse, Python, Go, CSPM, Cloud Foundry, BOSH_
 
-- Worked with a small, elite consultancy specializing in helping companies transform their infrastructure and processes to embrace software development practices such as continuous deployment, and their software to work in a cloud native manner.
-- Developed Kubernetes controllers in Go and created complex CI pipelines using Concourse, GitHub Actions, and GitLab pipelines.
-- Helped transform hugely complex projects at enterprise level to become more manageable, scalable, and declarative, prioritizing reproducibility and resilience to drift over strictly GitOps based workflows.
-- Implemented Cloud Security Posture Management policies across various platforms, including successfully convincing Microsoft during a Paddington office visit to add features and scope to Azure Policy tool for implementing various checks.
-- Built code & deployment auditing tools using Python for enterprise clients.
-- Contributed to open source projects including Kubernetes External Secrets Operator and the development of Compliance Framework, a verified CSPM auditing tool.
+- Cloud native consultancy — helping companies unfuck their infrastructure and adopt proper deployment practices.
+- Wrote Kubernetes controllers in Go, built CI pipelines in Concourse, GitHub Actions, and GitLab.
+- Took messy enterprise projects and made them reproducible and declarative. Pragmatic about GitOps — resilience to drift matters more than dogma.
+- Implemented CSPM policies across platforms. Convinced Microsoft to add features to Azure Policy during a Paddington office visit.
+- Built deployment auditing tools in Python for enterprise clients.
+- Contributed to Kubernetes External Secrets Operator and Compliance Framework (CSPM auditing tool).
 
 ### Lead Full Stack / Mobile Engineer, [Superbike Factory](https://superbikefactory.co.uk/) (Freelance) <small>Jan 2021–Apr 2023</small>
 
 _Key Skills: React, AWS, TypeScript, React Native, API Gateway, AWS CDK, REST API, DynamoDB_
 
-- Built an entire internal Android app and infrastructure from scratch for bike delivery drivers, featuring job viewing, note, and photo uploads, training (quizzes and videos), and customer payment functionality.
-- Enjoyed having free rein of a completely greenfield project, creating something fast, efficient, and reasonably low-cost using IaC, GitOps, CDK, Lambda, DynamoDB, and API Gateway to seamlessly integrate with existing systems.
-- Developed the frontend using React Native, MobX-State-Tree, and minimal AWS Amplify components.
-- Created a highly integrated BitBucket Pipeline that deploys infrastructure, uses CloudFront outputs dynamically, and builds the app with zero manual configuration — everything is completely dynamic with minimal environment configuration needed.
-- Audited existing infrastructure code and implemented security patches and enhancements.
+- Greenfield project — built an internal Android app and all its infrastructure from scratch for bike delivery drivers. Jobs, photos, training, payments.
+- Kept it cheap and fast: CDK, Lambda, DynamoDB, API Gateway, all IaC, integrated with their existing systems.
+- React Native frontend with MobX-State-Tree.
+- BitBucket Pipeline that deploys infra and builds the app with zero manual config — fully dynamic, no env vars to babysit.
+- Audited their existing infra and patched security holes.
 
 ### Lead Developer, [ROXi](https://roxi.tv) <small>Jan 2020–Jan 2022</small>
 
 _Key Skills: React, Astro, AWS, TypeScript, React Native, Java, Swift, Node.js, WebSockets_
 
-- Built several key projects from scratch including the "Companion App" in React Native, which uniquely used my approach for low-latency LAN communication via a WebSocket server running on the phone. This was necessary due to constraints of the TV app running within a browser context.
-- Implemented native WebSocket libraries for both Android (Java) and iOS (Swift) platforms as React Native modules, including work to ensure thread safety on iOS using Grand Central Dispatch.
-- Created internal curation tools using MobX-State-Tree, Tailwind, and Vite for enhanced performance.
-- Designed and built a statically generated e-commerce website with account servicing functionality using the then-new Astro framework (based on Vite).
+- Built the "Companion App" in React Native — ran a WebSocket server on the phone for low-latency LAN communication with the TV app (which was stuck in a browser context, so this was the workaround).
+- Wrote native WebSocket modules for Android (Java) and iOS (Swift), including thread safety via Grand Central Dispatch on iOS.
+- Built internal curation tools with MobX-State-Tree, Tailwind, and Vite.
+- Built their e-commerce site as a static Astro site back when Astro was brand new.
 
 ### Lead Frontend Developer, [Sapien Interactive](https://bootbag.co) (Freelance) <small>Jan 2020–Jan 2024</small>
 
 _Key Skills: React, TypeScript, React Native, Node.js, Firebase, MobX-State-Tree, WebSockets_
 
-- Recruited by a former business partner to build the application for both a startup venture and a reboot of an earlier project using React Native and Firebase.
-- Implemented MobX-State-Tree to achieve extremely high performance using observables, mutable style updates, and flows for side-effects, all with minimal boilerplate.
-- Initially skeptical due to preference for explicit, functional style immutability used in Redux, but approached with open mind and successfully refactored codebase from class components to modern functional components wrapped by mobx-react observers using hooks.
-- Discovered the simplicity and elegance of MobX made it worth the paradigm shift from Redux.
+- Former business partner pulled me in to build React Native + Firebase apps for a startup and a reboot of an earlier project.
+- Used MobX-State-Tree for state — observables, flows, minimal boilerplate. Came from a Redux background and was skeptical, but the simplicity won me over.
+- Refactored the codebase from class components to functional components with mobx-react observers and hooks.
 
 ### Senior Mobile Developer, [Zopa Financial Services](https://zopa.com) <small>Jan 2018–Jan 2020</small>
 
 _Key Skills: React, TypeScript, React Native, Redux, Zeplin, Java, Kafka, Kotlin, Swift_
 
-- Led development of the credit-card section of Zopa's app using React Native and Redux.
-- Built native modules for the React Native app using Swift and Kotlin for brand new Stripe card issuing APIs.
-- Learned extensively about React Native while maintaining a well-kept, up-to-date codebase that leveraged new tech like hooks as soon as feasible and appropriate.
-- Ensured code quality through well-reviewed, thoroughly tested code using detox and @testing-library/react-native.
-- Developed strong connections with analysts and backend developers, even fixing backend bugs, while learning financial products and requirements in depth to be more effective as an engineer.
+- Owned the credit card section of Zopa's React Native app with Redux.
+- Wrote native modules in Swift and Kotlin for Stripe's (then brand new) card issuing APIs.
+- Kept the codebase modern — adopted hooks early, maintained solid test coverage with detox and @testing-library/react-native.
+- Worked closely with analysts and backend devs, fixed backend bugs when needed. Learned the financial domain properly rather than just pushing pixels.
 
 ## Skills
 
@@ -123,7 +115,7 @@ Git, SVN, BDD, TDD, Vagrant, Nginx, Apache, Agile, JIRA, Trello, Linux
 
 ## Who is James?
 
-I don't see programming and computers as simply a job, but part of who I am. I think the world is going through very interesting times and it will be passionate programmers and thinkers that will play an important part in shaping it. My current hobbies are photography (events, portrait, street, travel), and I'm an avid cyclist (mainly fixed, but also gravel). When I lived in Brighton I often helped out with putting on shows and DJing at club nights. I enjoy going out with friends and finding new bands or other weird and wonderful things to do. I am a keen follower of current affairs, especially from a technical standpoint, and think a lot about the world and am interested by new developments politically and scientifically.
+Outside of work: photography (events, portrait, street, travel), cycling (fixed gear mostly, some gravel). Used to put on shows and DJ club nights in Brighton. I follow current affairs and keep up with what's happening in tech, politics, and science.
 
 ## Less Recent Work
 
@@ -131,18 +123,17 @@ I don't see programming and computers as simply a job, but part of who I am. I t
 
 _Key Skills: React, TypeScript, Redux, Go, Node.js, API Gateway, Apigee, Auth0_
 
-- Developed the allocation UI responsible for controllers allocating deliveries and bookings to couriers.
-- Refactored entire codebase to use modern practices and patterns including Redux, redux-observable for side-effects, and React 16.
-- Took ownership of the authentication framework (Auth0), authorization system (AWS Lambda and JWT), and various services for user management and automated API aggregation using Swagger, AWS API Gateway, and Apigee.
+- Built the allocation UI for dispatching deliveries to couriers.
+- Refactored the codebase to Redux, redux-observable, and React 16.
+- Owned auth (Auth0), authorization (Lambda + JWT), and user management services. Built automated API aggregation with Swagger, API Gateway, and Apigee.
 
 ### Lead Frontend Developer, [SmartFocus](https://www.actito.com) <small>Mar 2015–Jan 2017</small>
 
 _Key Skills: React, AngularJS, Redux, Redis, Node.js, flux, WebSockets, Express, ZeroMQ, C++, C#, .NET, Qt_
 
-- Lead Software Engineer in the innovation and front-end teams, built, and rebuilt vast amounts of frontend code and internal services.
-- Architected and built three mainstay current and future products while mentoring other engineers.
-- Created patterns and practices widely commended within the technical team.
-- Quickly tapped into skills across database architecture, general architecture, UX, and product design to solve problems and improve solutions.
+- Led innovation and frontend teams. Built and rebuilt large chunks of frontend code and internal services.
+- Architected three core products while mentoring engineers.
+- Wore many hats — database architecture, UX, product design — whatever the problem needed.
 
 ### Lead Frontend Developer, Bootbag <small>Jan 2014–Jan 2015</small>
 
@@ -154,11 +145,10 @@ _Key Skills: React, CSS, Redux, HTML, flux, WebSockets_
 
 _Key Skills: PHP, React, AngularJS, Django, jQuery, Node.js, Linux, nginx, Express, .NET, C#_
 
-- Worked as Technical Director for a small Brighton based agency.
-- Took projects from ideas in clients' heads to fully developed products using Django, AngularJS, jQuery, and PHP.
+- Technical Director at a small Brighton agency. Took projects from vague client ideas to shipped products — Django, AngularJS, jQuery, PHP.
 
 ### Web Developer, Freelance <small>Jan 2010–Jan 2013</small>
 
 _Key Skills: PHP, AngularJS, Django, jQuery, Node.js, Flask, Linux, nginx, Apache_
 
-- Dropped into the deep end when moving to Brighton, rapidly learned to network, project manage, and rely on quickly improving technical skills to meet demand.
+- Moved to Brighton and went freelance. Learned to hustle — networking, project management, and levelling up technically to keep up with demand.


### PR DESCRIPTION
## Summary
- Rewrote professional summary — cut the "thrives in challenges" / "passionate about" / "natural creative" corporate theatre
- Stripped all job descriptions of buzzword padding ("instrumental in delivering", "managing requirements in a fast-paced environment", "facilitating the migration")
- Made the "Who is James?" section concise instead of a motivational speech
- Kept all facts, dates, skills, and links intact — just killed the cringe

## Test plan
- [ ] Verify site builds: `bun run build`
- [ ] Check CV renders correctly at `/cv`
- [ ] Read it and confirm it doesn't make you cringe

🤖 Generated with [Claude Code](https://claude.com/claude-code)