### PR TITLE
fix(i18n): audit and correct translations across 18 locales

### DIFF
--- a/src/locales/ar-EG/messages.po
+++ b/src/locales/ar-EG/messages.po
@@ -21,7 +21,7 @@ msgstr "جيمس كليفلاند"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "جيمس كليفلاند : مهندس برمجيات كامل متقدم"
+msgstr "جيمس كليفلاند : مهندس فول ستاك كبير"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/ar-PS/messages.po
+++ b/src/locales/ar-PS/messages.po
@@ -21,7 +21,7 @@ msgstr "جيمس كليفلاند"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "جيمس كليفلاند : مهندس برمجيات كامل متقدم"
+msgstr "جيمس كليفلاند : مهندس فول ستاك كبير"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/bo-CN/messages.po
+++ b/src/locales/bo-CN/messages.po
@@ -16,13 +16,13 @@ msgstr ""
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:9
 msgid "james cleveland"
-msgstr "ཇེམས་ཀླིབ་ལེནཌ་"
+msgstr "ཇེམས་ཀི་ལིཝ་ལེནཌ་"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "ཇེམས་ཀླིབ་ལེནཌ་ : མཐོ་རིམ་ཕུལ་བྱུང་ཚང་མ་འགོ་སྒྲིག་པ་"
+msgstr "ཇེམས་ཀི་ལིཝ་ལེནཌ་ : སིནིཡར་ཕུལ་སི་ཊེཀ་ ཨིན་ཇི་ནིཡར་"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -21,7 +21,7 @@ msgstr "james cleveland"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "james cleveland : senior full stack entwickler"
+msgstr "james cleveland : senior full stack ingenieur"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/it-IT/messages.po
+++ b/src/locales/it-IT/messages.po
@@ -21,7 +21,7 @@ msgstr "james cleveland"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "james cleveland : senior ingegnere full stack"
+msgstr "james cleveland : ingegnere full stack senior"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/km-KH/messages.po
+++ b/src/locales/km-KH/messages.po
@@ -16,13 +16,13 @@ msgstr ""
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:9
 msgid "james cleveland"
-msgstr "ជេមស៍ ឃ្លីវលែន"
+msgstr "ជេមស៍ ឃ្លីវលែនដ៍"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "ជេមស៍ ឃ្លីវលែន : វិស្វករ Full Stack ជាន់ខ្ពស់"
+msgstr "ជេមស៍ ឃ្លីវលែនដ៍ : វិស្វករ Full Stack ជាន់ខ្ពស់"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/kn-IN/messages.po
+++ b/src/locales/kn-IN/messages.po
@@ -22,7 +22,7 @@ msgstr "ಜೇಮ್ಸ್ ಕ್ಲೀವ್‌ಲ್ಯಾಂಡ್"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "ಜೇಮ್ಸ್ ಕ್ಲೀವ್‌ಲ್ಯಾಂಡ್ : ಹಿರಿಯ ಪೂರ್ಣ ಸ್ಟಾಕ್ ಇಂಜಿನಿಯರ್"
+msgstr "ಜೇಮ್ಸ್ ಕ್ಲೀವ್‌ಲ್ಯಾಂಡ್ : ಸೀನಿಯರ್ ಫುಲ್ ಸ್ಟಾಕ್ ಇಂಜಿನಿಯರ್"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/mn-MN/messages.po
+++ b/src/locales/mn-MN/messages.po
@@ -16,13 +16,13 @@ msgstr ""
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:9
 msgid "james cleveland"
-msgstr "Жеймс Кливленд"
+msgstr "Жэймс Кливленд"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "Жеймс Кливленд : ахлах фулл стэк инженер"
+msgstr "Жэймс Кливленд : ахлах фулл стэк инженер"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/my-MM/messages.po
+++ b/src/locales/my-MM/messages.po
@@ -16,13 +16,13 @@ msgstr ""
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:9
 msgid "james cleveland"
-msgstr "ဂျိမ်းစ် ကလီဗလန်"
+msgstr "ဂျေးမ်စ် ကလီဗလန်ဒ်"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "ဂျိမ်းစ် ကလီဗလန် : အကြီးတန်း ဖူးစတက် အင်ဂျင်နီယာ"
+msgstr "ဂျေးမ်စ် ကလီဗလန်ဒ် : အကြီးတန်း ဖူးလ်စတက် အင်ဂျင်နီယာ"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/ne-NP/messages.po
+++ b/src/locales/ne-NP/messages.po
@@ -22,7 +22,7 @@ msgstr "जेम्स क्लिभल्यान्ड"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "जेम्स क्लिभल्यान्ड : वरिष्ठ पूर्ण स्ट्याक इन्जिनियर"
+msgstr "जेम्स क्लिभल्यान्ड : सिनियर फुल स्ट्याक इन्जिनियर"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/nl-BE/messages.po
+++ b/src/locales/nl-BE/messages.po
@@ -21,12 +21,12 @@ msgstr "james cleveland"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "james cleveland : senior full stack ontwikkelaar"
+msgstr "james cleveland : senior full stack ingenieur"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15
 msgid "cv-2025.01"
-msgstr "curriculum vitae-2025.01"
+msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:16

--- a/src/locales/nl-NL/messages.po
+++ b/src/locales/nl-NL/messages.po
@@ -21,7 +21,7 @@ msgstr "james cleveland"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "james cleveland : senior full stack ontwikkelaar"
+msgstr "james cleveland : senior full stack ingenieur"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/pa-IN/messages.po
+++ b/src/locales/pa-IN/messages.po
@@ -22,7 +22,7 @@ msgstr "ਜੇਮਸ ਕਲੀਵਲੈਂਡ"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "ਜੇਮਸ ਕਲੀਵਲੈਂਡ : ਸੀਨੀਅਰ ਫੁੱਲ ਸਟੈਕ ਇੰਜੀਨੀਅਰ"
+msgstr "ਜੇਮਸ ਕਲੀਵਲੈਂਡ : ਸੀਨੀਅਰ ਫੁਲ ਸਟੈਕ ਇੰਜੀਨੀਅਰ"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/pl-PL/messages.po
+++ b/src/locales/pl-PL/messages.po
@@ -26,7 +26,7 @@ msgstr "james cleveland : starszy inżynier full stack"
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15
 msgid "cv-2025.01"
-msgstr "życiorys-2025.01"
+msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:16

--- a/src/locales/si-LK/messages.po
+++ b/src/locales/si-LK/messages.po
@@ -22,7 +22,7 @@ msgstr "ජේම්ස් ක්ලීව්ලන්ඩ්"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "ජේම්ස් ක්ලීව්ලන්ඩ් : ජ්‍යෙෂ්ඨ සම්පූර්ණ ස්ටැක් ඉංජිනේරු"
+msgstr "ජේම්ස් ක්ලීව්ලන්ඩ් : සීනියර් ෆුල් ස්ටැක් ඉංජිනේරු"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/ta-IN/messages.po
+++ b/src/locales/ta-IN/messages.po
@@ -22,7 +22,7 @@ msgstr "ஜேம்ஸ் கிளீவ்லாந்து"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "ஜேம்ஸ் கிளீவ்லாந்து : மூத்த ஃபுல் ஸ்டேக் பொறியாளர்"
+msgstr "ஜேம்ஸ் கிளீவ்லாந்து : சீனியர் ஃபுல் ஸ்டேக் என்ஜினியர்"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/th-TH/messages.po
+++ b/src/locales/th-TH/messages.po
@@ -22,7 +22,7 @@ msgstr "เจมส์ คลีฟแลนด์"
 #: %3Cstdin%3E:11
 #: %3Cstdin%3E:16
 msgid "james cleveland : senior full stack engineer"
-msgstr "เจมส์ คลีฟแลนด์ : วิศวกรซอฟต์แวร์อาวุโสแบบฟูลสแตก"
+msgstr "เจมส์ คลีฟแลนด์ : วิศวกรฟูลสแตกอาวุโส"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15

--- a/src/locales/zh-TW/messages.po
+++ b/src/locales/zh-TW/messages.po
@@ -27,7 +27,7 @@ msgstr "詹姆斯·克利夫蘭：資深全端工程師"
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:15
 msgid "cv-2025.01"
-msgstr "cv-2025.01"
+msgstr "履歷-2025.01"
 
 #. js-lingui-explicit-id
 #: %3Cstdin%3E:16


### PR DESCRIPTION
## Summary

Full translation audit of all 37 locales. Fixed 18 .po files.

### Critical

- **bo-CN** (Tibetan): Name transliteration `ཀླིབ` means "impotent/eunuch" in Tibetan. Role title was nonsensical ("excellent all-encompassing organizer"). Full redo with transliterated tech terms.

### Wrong translations

| Locale | Issue | Fix |
|--------|-------|-----|
| **de-DE** | "Entwickler" (developer) | → "Ingenieur" (engineer) |
| **nl-BE, nl-NL** | "ontwikkelaar" (developer) | → "ingenieur" (engineer) |
| **ar-EG, ar-PS** | Injected "software", used "advanced" for senior | → removed "software", كبير for senior |
| **pa-IN** | ਫੁੱਲ with adhak = "flower" | → ਫੁਲ without adhak = "full" |
| **pl-PL** | "życiorys" (biography) for CV link | → "cv" |
| **th-TH** | Injected "software" (ซอฟต์แวร์) | → removed |
| **nl-BE** | "curriculum vitae-2025.01" verbose | → "cv-2025.01" |

### Awkward / inconsistent

| Locale | Issue | Fix |
|--------|-------|-----|
| **kn-IN, si-LK** | "elder complete stack" native/transliterated hybrid | → consistent transliteration |
| **ta-IN, ne-NP** | Mixed native/transliterated strategy | → consistent transliteration |
| **km-KH** | Missing final "d" in Cleveland | → added ដ៍ |
| **my-MM** | James transliteration off, "full" lost "l" | → fixed both |
| **mn-MN** | Жеймс (wrong vowel) | → Жэймс |
| **zh-TW** | CV link not localized (zh-CN did it) | → 履歷-2025.01 |
| **it-IT** | "senior ingegnere" word order | → "ingegnere senior" |

### Not changed (verified correct)

en-GB, fr-FR, ja-JP, ko-KR, zh-CN, vi-VN, uk-UA, el-GR, hy-AM, ka-GE, hi-IN, bn-BD, te-IN, gu-IN, ml-IN, or-IN, lo-LA, am-ET, dv-MV

## Test plan

- [ ] `bun run build` succeeds with all 76 pages prerendered
- [ ] Spot-check a few fixed locales in the output HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)