### PR TITLE
ci: build on runner via aube-action, thin Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+!dist/client
 .git
 .github
 *.log

--- a/.github/workflows/publish-web-container.yml
+++ b/.github/workflows/publish-web-container.yml
@@ -26,14 +26,51 @@ on:
   pull_request:
 
 jobs:
-  build-and-publish:
+  build:
     runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install aube
+        uses: endevco/aube-action@f82ca2f6c943dbde1904945d9f0ee1a0faf8e945 # v1.0.0
+        with:
+          node-version: auto
+          run-install: true
+          install-args: --frozen-lockfile
+
+      - name: Lint
+        run: aube run lint
+
+      - name: Typecheck
+        run: aube run typecheck
+
+      - name: Build
+        run: aube run build
+
+      - name: Upload built site
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist-client
+          path: dist/client
+          retention-days: 7
+          if-no-files-found: error
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
     permissions:
       packages: write
       contents: read
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Download built site
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist-client
+          path: dist/client
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
@@ -73,7 +110,7 @@ jobs:
 
   update-deployment:
     runs-on: ubuntu-latest
-    needs: build-and-publish
+    needs: publish
     if: github.ref == 'refs/heads/main'
 
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@
 ### Tooling
 
 - Switched package manager from Bun to [aube](https://aube.en.dev) (pnpm-style isolated `node_modules`, `aube-lock.yaml`)
-- Docker base image: `oven/bun:latest` → `node:24-alpine` with aube installed via npm — aube does not bundle a runtime
 - Build-script allowlist moved from bun's `trustedDependencies` to aube's `allowBuilds` (sharp, workerd, esbuild, lefthook)
+
+### CI
+
+- CI now installs aube via [`endevco/aube-action`](https://github.com/endevco/aube-action) (SHA-pinned to v1.0.0) and runs lint + typecheck + build on the runner
+- Docker pipeline split: runner builds `dist/client/` and uploads it as an artifact; the publish job downloads it and packages a thin image (just `FROM nano-web` + `COPY dist/client /public`)
+- Dockerfile no longer needs Node, npm, or aube — final image is just static assets on top of nano-web
 
 ## 4.0.0 — 2026-04-11
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,5 @@
 # syntax=docker/dockerfile:1.2
-FROM node:24-alpine AS deps
-WORKDIR /app
-RUN npm install -g --ignore-scripts=false @endevco/aube
-COPY package.json aube-lock.yaml ./
-RUN --mount=type=cache,target=/root/.local/share/aube/store \
-    aube ci
-
-FROM deps AS builder
-COPY . .
-RUN aube run build
-
-FROM ghcr.io/radiosilence/nano-web:latest AS runner
-COPY --from=builder /app/dist/client /public
+FROM ghcr.io/radiosilence/nano-web:latest
+COPY dist/client /public
 ENV PORT=3000
 EXPOSE 3000


### PR DESCRIPTION
> Stacked on top of #10. Change base to \`main\` after #10 merges.

## Summary

- New \`build\` job uses [\`endevco/aube-action\`](https://github.com/endevco/aube-action) (SHA-pinned to v1.0.0) with \`node-version: auto\` to pick up \`node = "24"\` from \`mise.toml\`. Runs \`aube install --frozen-lockfile\` then \`aube run lint\`, \`aube run typecheck\`, \`aube run build\` on the runner. Uploads \`dist/client/\` as a build artifact.
- New \`publish\` job downloads the artifact and runs docker build/push. Renamed from \`build-and-publish\` since the build itself moved.
- \`update-deployment\` now \`needs: publish\` (was \`build-and-publish\`).
- Dockerfile collapses from a 3-stage node/builder/runner pipeline to a single \`FROM nano-web\` + \`COPY dist/client /public\`. No Node, npm, or aube in the final image.
- \`.dockerignore\` adds \`!dist/client\` so the artifact can reach the daemon.

## Pinned SHAs

| Action | SHA | Tag |
|---|---|---|
| \`endevco/aube-action\` | \`f82ca2f6c943dbde1904945d9f0ee1a0faf8e945\` | v1.0.0 |
| \`actions/upload-artifact\` | \`ea165f8d65b6e75b540449e92b4886f43607fa02\` | v4.6.2 |
| \`actions/download-artifact\` | \`d3f86a106a0bac45b974a628896c90dbdf5c8093\` | v4.3.0 |

## Test plan

- [ ] \`build\` job: aube install, lint, typecheck, build all green; artifact uploaded
- [ ] \`publish\` job: artifact downloaded, docker build succeeds, image pushed on main
- [ ] \`update-deployment\` triggers on main and pushes the tag bump
- [ ] Final image smaller than the previous bun-based one (less stuff in it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)