### PR TITLE
chore(security): aube-workspace.yaml with secure defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Switched package manager from Bun to [aube](https://aube.en.dev) (pnpm-style isolated `node_modules`, `aube-lock.yaml`)
 - Docker base image: `oven/bun:latest` → `node:24-alpine` with aube installed via npm — aube does not bundle a runtime
-- Build-script allowlist moved from bun's `trustedDependencies` to aube's `allowBuilds` (sharp, workerd, esbuild, lefthook)
+- Added `aube-workspace.yaml` with security-focused defaults: `minimumReleaseAge: 10080` (7-day install delay), `trustPolicy: no-downgrade`, explicit `blockExoticSubdeps`. Build-script allowlist consolidated here (moved out of `package.json`).
 
 ## 4.0.0 — 2026-04-11
 

--- a/aube-workspace.yaml
+++ b/aube-workspace.yaml
@@ -1,0 +1,26 @@
+# aube workspace config — security-focused defaults.
+# Docs: https://aube.en.dev/security.html
+
+# Minutes between a package being published and aube being willing to install
+# it. 7 days (10080 min) buys us a window for the registry / community to
+# catch and yank malicious releases before they reach our lockfile.
+# Default is 1440 (1 day).
+minimumReleaseAge: 10080
+
+# Refuse to install a version whose trust evidence is weaker than an earlier
+# release (eg. lost provenance, dropped signature). Mitigates downgrade
+# attacks where an attacker republishes a "patched" version with weaker
+# verifiability.
+trustPolicy: no-downgrade
+
+# Reject git/file/tarball transitive deps — only registry packages allowed
+# below the top level. Default is true; pinned here so it stays that way.
+blockExoticSubdeps: true
+
+# Lifecycle scripts that may run during install. Moved from
+# package.json#aube.allowBuilds.
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  sharp: true
+  workerd: true

--- a/package.json
+++ b/package.json
@@ -49,13 +49,5 @@
     "typescript": "~6.0.3",
     "vite": "^8.0.11",
     "wrangler": "^4.90.0"
-  },
-  "aube": {
-    "allowBuilds": {
-      "esbuild": true,
-      "lefthook": true,
-      "sharp": true,
-      "workerd": true
-    }
   }
 }


### PR DESCRIPTION
## Summary

Adds \`aube-workspace.yaml\` to lock down supply-chain defaults.

\`\`\`yaml
minimumReleaseAge: 10080   # 7 days — wait for the registry to catch yanks
trustPolicy: no-downgrade  # block versions with weaker trust evidence
blockExoticSubdeps: true   # no git/file/tarball transitives (explicit; default is true)
allowBuilds:               # moved out of package.json#aube.allowBuilds
  esbuild: true
  lefthook: true
  sharp: true
  workerd: true
\`\`\`

### Why minimumReleaseAge: 10080

aube's default is 1 day (1440 min). Most malicious npm releases get caught and yanked within the first few days. A 7-day delay means our lockfile only ever sees versions the broader ecosystem has had a chance to vet. Applies during resolution (\`aube add\` / \`aube update\`), not during \`--frozen-lockfile\` installs of existing pins, so it doesn't slow down CI.

### Why trustPolicy: no-downgrade

Refuses to install a version whose provenance/signature is weaker than an earlier release. Mitigates downgrade attacks where an attacker republishes a "patched" version with weaker verifiability.

### allowBuilds consolidation

Was in \`package.json#aube.allowBuilds\`. Moved to \`aube-workspace.yaml\` since aube's docs treat workspace yaml as the canonical location (\`aube approve-builds\` writes there).

## Test plan

- [x] \`aube install --frozen-lockfile\` — clean, no build-script warnings (allowBuilds picked up from new location)
- [x] \`aube run typecheck\` — exit 0
- [x] \`aube run lint\` — 0 warnings, 0 errors
- [x] \`aube run build\` — exit 0, 76 pages prerendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)