### PR TITLE
chore: dep updates — within-semver + @lingui v6 + tanstack/devtools-vite v0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Dependencies
+
+- **@lingui/cli + @lingui/vite-plugin → v6.0.1** (major): ESM-only distribution, requires Node 22.19+. Dropped explicit `format: "po"` from `lingui.config.ts` — v6 defaults to the `po` formatter when no format is specified. No catalog format change for our setup (no `formatOptions` were in use). Refreshed `.po` source-location comments via `lingui extract` to reflect current file layout.
+- **@tanstack/devtools-vite → v0.7.0** (major): in-place, no API breakage for our `vite.config.ts` usage.
+- Within-semver batch: `@cloudflare/vite-plugin`, `@tanstack/router-plugin`, `@tanstack/react-devtools`, `@tanstack/react-router`, `@tanstack/react-start`, `@vitejs/plugin-react`, `oxlint`, `oxfmt`, `react`, `react-dom`, `vite`, `wrangler`.
+
 ### Tooling
 
 - Switched package manager from Bun to [aube](https://aube.en.dev) (pnpm-style isolated `node_modules`, `aube-lock.yaml`)

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -1,1503 +1,497 @@
-lockfileVersion: "9.0"
+lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+time:
+  '@lingui/babel-plugin-extract-messages@6.0.1': 2026-04-30T15:19:12.439Z
+  '@lingui/cli@6.0.1': 2026-04-30T15:19:15.271Z
+  '@lingui/format-po@6.0.1': 2026-04-30T15:19:06.189Z
+  '@lingui/vite-plugin@6.0.1': 2026-04-30T15:19:17.987Z
+  '@oxfmt/binding-darwin-arm64@0.49.0': 2026-05-11T18:49:15.026Z
+  '@oxfmt/binding-linux-arm64-gnu@0.49.0': 2026-05-11T18:49:31.141Z
+  '@oxfmt/binding-linux-arm64-musl@0.49.0': 2026-05-11T18:49:35.946Z
+  '@oxfmt/binding-linux-x64-gnu@0.49.0': 2026-05-11T18:50:37.625Z
+  '@oxfmt/binding-linux-x64-musl@0.49.0': 2026-05-11T18:50:42.076Z
+  '@oxfmt/binding-win32-arm64-msvc@0.49.0': 2026-05-11T18:49:26.491Z
+  '@oxfmt/binding-win32-x64-msvc@0.49.0': 2026-05-11T18:50:28.795Z
+  '@tanstack/devtools-vite@0.7.0': 2026-05-13T14:47:09.428Z
+  '@tanstack/react-devtools@0.10.5': 2026-05-13T10:21:52.170Z
+  '@tanstack/react-router-devtools@1.166.13': 2026-04-11T11:24:53.981Z
+  '@tanstack/react-router-ssr-query@1.166.12': 2026-04-25T20:39:36.057Z
+  '@tanstack/react-router@1.169.2': 2026-05-05T20:37:38.526Z
+  '@tanstack/react-start@1.167.65': 2026-05-06T23:03:31.215Z
+  get-east-asian-width@1.6.0: 2026-05-08T06:36:55.498Z
+  mimic-function@5.0.1: 2024-03-14T08:37:42.297Z
+  oxfmt@0.49.0: 2026-05-11T18:50:47.581Z
+  stdin-discarder@0.3.2: 2026-04-14T07:35:35.513Z
+  yoctocolors@2.1.2: 2025-08-19T15:19:23.680Z
+
 importers:
+
   .:
     dependencies:
-      "@cloudflare/vite-plugin":
-        specifier: ^1.36.3
-        version: 1.36.3
-      "@lingui/core":
+      '@babel/core':
+        specifier: ^7.29.0 || ^8.0.0-rc.1
+        version: 7.29.0
+      '@cloudflare/vite-plugin':
+        specifier: ^1.37.0
+        version: 1.37.0(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))(wrangler@4.91.0)
+      '@lingui/babel-plugin-lingui-macro':
+        specifier: ^5 || ^6
+        version: 6.0.1
+      '@lingui/core':
         specifier: ^6.0.1
         version: 6.0.1
-      "@lingui/react":
+      '@lingui/react':
         specifier: ^6.0.1
-        version: 6.0.1
-      "@tanstack/react-devtools":
+        version: 6.0.1(react@19.2.6)
+      '@tanstack/query-core':
+        specifier: '>=5.90.0'
+        version: 5.100.8
+      '@tanstack/react-devtools':
         specifier: latest
-        version: 0.10.2
-      "@tanstack/react-router":
+        version: 0.10.5(@types/react@19.2.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-query':
+        specifier: '>=5.90.0'
+        version: 5.100.8(react@19.2.6)
+      '@tanstack/react-router':
         specifier: latest
-        version: 1.169.1
-      "@tanstack/react-router-devtools":
+        version: 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-router-devtools':
         specifier: latest
-        version: 1.166.13
-      "@tanstack/react-router-ssr-query":
+        version: 1.166.13(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(@tanstack/router-core@1.169.2)(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-router-ssr-query':
         specifier: latest
-        version: 1.166.12
-      "@tanstack/react-start":
+        version: 1.166.12(@tanstack/query-core@5.100.8)(@tanstack/react-query@5.100.8(react@19.2.6))(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-start':
         specifier: latest
-        version: 1.167.59
-      "@tanstack/router-plugin":
-        specifier: ^1.132.0
-        version: 1.167.12
+        version: 1.167.65(react@19.2.6)(react-dom@19.2.6(react@19.2.6))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
+      '@tanstack/router-core':
+        specifier: ^1.168.11
+        version: 1.169.2(seroval@1.5.4)
+      '@tanstack/router-plugin':
+        specifier: ^1.167.35
+        version: 1.167.35(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
+      '@types/node':
+        specifier: ^20.19.0 || >=22.12.0
+        version: 25.5.2
+      esbuild:
+        specifier: ^0.27.0 || ^0.28.0
+        version: 0.27.3
+      jiti:
+        specifier: '>=1.21.0'
+        version: 2.7.0
       react:
-        specifier: ^19.2.4
-        version: 19.2.4
+        specifier: ^19.2.6
+        version: 19.2.6
       react-dom:
-        specifier: ^19.2.4
-        version: 19.2.4
+        specifier: ^19.2.6
+        version: 19.2.6(react@19.2.6)
+      rolldown:
+        specifier: ^1.0.0-rc.5
+        version: 1.0.1
+      rollup:
+        specifier: '>=2'
+        version: 4.60.1
     devDependencies:
-      "@lingui/cli":
-        specifier: ^5.9.4
-        version: 5.9.4
-      "@lingui/vite-plugin":
-        specifier: ^5.9.4
-        version: 5.9.4
-      "@mdx-js/rollup":
+      '@lingui/cli':
+        specifier: ^6.0.1
+        version: 6.0.1
+      '@lingui/vite-plugin':
+        specifier: ^6.0.1
+        version: 6.0.1(@babel/core@7.29.0)(@lingui/babel-plugin-lingui-macro@6.0.1)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
+      '@mdx-js/rollup':
         specifier: ^3.1.1
-        version: 3.1.1
-      "@tailwindcss/typography":
+        version: 3.1.1(rollup@4.60.1)
+      '@tailwindcss/typography':
         specifier: ^0.5.19
-        version: 0.5.19
-      "@tailwindcss/vite":
+        version: 0.5.19(tailwindcss@4.3.0)
+      '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0
-      "@tanstack/devtools-vite":
+        version: 4.3.0(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
+      '@tanstack/devtools-vite':
         specifier: latest
-        version: 0.6.0
-      "@types/mdx":
+        version: 0.7.0(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
+      '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
-      "@types/react":
+      '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
-      "@types/react-dom":
+      '@types/react-dom':
         specifier: ^19.2.3
-        version: 19.2.3
-      "@vitejs/plugin-react":
-        specifier: ^6.0.1
-        version: 6.0.1
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
       oxfmt:
-        specifier: ^0.48.0
-        version: 0.48.0
+        specifier: ^0.49.0
+        version: 0.49.0
       oxlint:
-        specifier: ^1.63.0
-        version: 1.63.0
+        specifier: ^1.64.0
+        version: 1.64.0
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
       tailwindcss-logical:
         specifier: ^4.2.0
-        version: 4.2.0
+        version: 4.2.0(tailwindcss@4.3.0)
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.0.11
-        version: 8.0.11
+        specifier: ^8.0.13
+        version: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
       wrangler:
-        specifier: ^4.90.0
-        version: 4.90.0
+        specifier: ^4.91.0
+        version: 4.91.0
 
 packages:
-  "@babel/code-frame@7.27.1":
-    resolution:
-      {
-        integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==,
-      }
 
-  "@babel/code-frame@7.29.0":
-    resolution:
-      {
-        integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==,
-      }
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
 
-  "@babel/compat-data@7.29.0":
-    resolution:
-      {
-        integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==,
-      }
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
 
-  "@babel/core@7.29.0":
-    resolution:
-      {
-        integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==,
-      }
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
 
-  "@babel/generator@7.29.1":
-    resolution:
-      {
-        integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==,
-      }
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
 
-  "@babel/helper-compilation-targets@7.28.6":
-    resolution:
-      {
-        integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==,
-      }
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
 
-  "@babel/helper-globals@7.28.0":
-    resolution:
-      {
-        integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==,
-      }
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
 
-  "@babel/helper-module-imports@7.28.6":
-    resolution:
-      {
-        integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==,
-      }
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
 
-  "@babel/helper-module-transforms@7.28.6":
-    resolution:
-      {
-        integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==,
-      }
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     peerDependencies:
-      "@babel/core": ^7.0.0
+      '@babel/core': ^7.0.0
 
-  "@babel/helper-plugin-utils@7.28.6":
-    resolution:
-      {
-        integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==,
-      }
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
 
-  "@babel/helper-string-parser@7.27.1":
-    resolution:
-      {
-        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
-      }
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
 
-  "@babel/helper-validator-identifier@7.28.5":
-    resolution:
-      {
-        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
-      }
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
 
-  "@babel/helper-validator-option@7.27.1":
-    resolution:
-      {
-        integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==,
-      }
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
 
-  "@babel/helpers@7.29.2":
-    resolution:
-      {
-        integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==,
-      }
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
 
-  "@babel/parser@7.29.2":
-    resolution:
-      {
-        integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==,
-      }
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     hasBin: true
 
-  "@babel/plugin-syntax-jsx@7.28.6":
-    resolution:
-      {
-        integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==,
-      }
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      '@babel/core': ^7.0.0-0
 
-  "@babel/plugin-syntax-typescript@7.28.6":
-    resolution:
-      {
-        integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==,
-      }
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
     peerDependencies:
-      "@babel/core": ^7.0.0-0
+      '@babel/core': ^7.0.0-0
 
-  "@babel/runtime@7.29.2":
-    resolution:
-      {
-        integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==,
-      }
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
 
-  "@babel/template@7.28.6":
-    resolution:
-      {
-        integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==,
-      }
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
 
-  "@babel/traverse@7.29.0":
-    resolution:
-      {
-        integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==,
-      }
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
 
-  "@babel/types@7.29.0":
-    resolution:
-      {
-        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
-      }
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
 
-  "@cloudflare/kv-asset-handler@0.5.0":
-    resolution:
-      {
-        integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==,
-      }
-
-  "@cloudflare/unenv-preset@2.16.1":
-    resolution:
-      {
-        integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==,
-      }
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
       unenv: 2.0.0-rc.24
-      workerd: ">1.20260305.0 <2.0.0-0"
+      workerd: '>1.20260305.0 <2.0.0-0'
     peerDependenciesMeta:
       workerd:
         optional: true
 
-  "@cloudflare/vite-plugin@1.36.3":
-    resolution:
-      {
-        integrity: sha512-n3SZhEZQxk4B2xHaCwgXfc7oLkx/4leTxL254P09DK2Qoj1VVOqVELo62CsUYq5dZS+okMdeWqNa13xEOKMs4g==,
-      }
+  '@cloudflare/vite-plugin@1.37.0':
+    resolution: {integrity: sha512-3A7TEe3j5PBJ99WeS7efnoc/IZRimpDeheNscd4icu2dFlOxci1ztb22LYONx62LVobqRffQ5WRtR1Z9dpCmTA==}
     peerDependencies:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
+      wrangler: ^4.91.0
 
-  "@cloudflare/workerd-darwin-64@1.20260507.1":
-    resolution:
-      {
-        integrity: sha512-S85aMwcaPJUjKWDiG6iMMnioKWtPLACa6m0j/EhHR1GYfVpnxb974cBc6d25L+sf7jHWHJI2u5hGp0UTJ7MtXQ==,
-      }
+  '@cloudflare/workerd-darwin-arm64@1.20260511.1':
+    resolution: {integrity: sha512-QOaY4/BlQfDEZgTlrwCPreRIyenYmFWREVP79SSz6K6QBf7bf8ubaATN11NZbouEg19iTMtl5L7FLYdcz1tz7g==}
+    engines: {node: '>=16'}
     os:
-      - darwin
+    - darwin
     cpu:
-      - x64
-
-  "@cloudflare/workerd-darwin-arm64@1.20260507.1":
-    resolution:
-      {
-        integrity: sha512-GMEBu8Zp9Q97HLnf7bWJN4KjWpN5MxpeqdvHjBGWNl8UYprJI0k+Jkp89+Wh5S8vIon+HoVbDfOzPa7VwgL6Eg==,
-      }
-    os:
-      - darwin
-    cpu:
-      - arm64
-
-  "@cloudflare/workerd-linux-64@1.20260507.1":
-    resolution:
-      {
-        integrity: sha512-QlrKEBdgA3uVc0Ok0Q3+0/CW0CTjgj5ySir1i1YY5FXVv0X6GpwtnB5umjunjF2MFprss+L+iFGZzxcSvMC1nA==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@cloudflare/workerd-linux-arm64@1.20260507.1":
-    resolution:
-      {
-        integrity: sha512-eGbbupEtK2nh9V9Dhcx3vv3GTKeXqSVNgAEYVCCN0NGS9tl9HbMoHRX/4JL181FKXROMigWBCQVL//qPhsAzBQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm64
-
-  "@cloudflare/workerd-windows-64@1.20260507.1":
-    resolution:
-      {
-        integrity: sha512-dmClJ/E0BAcuDetQIZFqbeAXejWrG5pysGRMQ6T83Y0IW/7IAamY2zFEkAJ10I5xwZsdHuYsZtzlOxpEXpJs7A==,
-      }
-    os:
-      - win32
-    cpu:
-      - x64
-
-  "@cspotcode/source-map-support@0.8.1":
-    resolution:
-      {
-        integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==,
-      }
-
-  "@emnapi/core@1.10.0":
-    resolution:
-      {
-        integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==,
-      }
-
-  "@emnapi/runtime@1.10.0":
-    resolution:
-      {
-        integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==,
-      }
-
-  "@emnapi/wasi-threads@1.2.1":
-    resolution:
-      {
-        integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
-      }
-
-  "@esbuild/aix-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-      }
-    os:
-      - aix
-    cpu:
-      - ppc64
-
-  "@esbuild/aix-ppc64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==,
-      }
-    os:
-      - aix
-    cpu:
-      - ppc64
-
-  "@esbuild/aix-ppc64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
-      }
-    os:
-      - aix
-    cpu:
-      - ppc64
-
-  "@esbuild/android-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
-      }
-    os:
-      - android
-    cpu:
-      - arm64
-
-  "@esbuild/android-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==,
-      }
-    os:
-      - android
-    cpu:
-      - arm64
-
-  "@esbuild/android-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
-      }
-    os:
-      - android
-    cpu:
-      - arm64
-
-  "@esbuild/android-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
-      }
-    os:
-      - android
-    cpu:
-      - arm
-
-  "@esbuild/android-arm@0.27.3":
-    resolution:
-      {
-        integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==,
-      }
-    os:
-      - android
-    cpu:
-      - arm
-
-  "@esbuild/android-arm@0.27.7":
-    resolution:
-      {
-        integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
-      }
-    os:
-      - android
-    cpu:
-      - arm
-
-  "@esbuild/android-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
-      }
-    os:
-      - android
-    cpu:
-      - x64
-
-  "@esbuild/android-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==,
-      }
-    os:
-      - android
-    cpu:
-      - x64
-
-  "@esbuild/android-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
-      }
-    os:
-      - android
-    cpu:
-      - x64
-
-  "@esbuild/darwin-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
-      }
-    os:
-      - darwin
-    cpu:
-      - arm64
-
-  "@esbuild/darwin-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==,
-      }
-    os:
-      - darwin
-    cpu:
-      - arm64
-
-  "@esbuild/darwin-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
-      }
-    os:
-      - darwin
-    cpu:
-      - arm64
-
-  "@esbuild/darwin-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
-      }
-    os:
-      - darwin
-    cpu:
-      - x64
-
-  "@esbuild/darwin-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==,
-      }
-    os:
-      - darwin
-    cpu:
-      - x64
-
-  "@esbuild/darwin-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
-      }
-    os:
-      - darwin
-    cpu:
-      - x64
-
-  "@esbuild/freebsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - arm64
-
-  "@esbuild/freebsd-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - arm64
-
-  "@esbuild/freebsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - arm64
-
-  "@esbuild/freebsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - x64
-
-  "@esbuild/freebsd-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - x64
-
-  "@esbuild/freebsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - x64
-
-  "@esbuild/linux-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm64
-
-  "@esbuild/linux-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm64
-
-  "@esbuild/linux-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm64
-
-  "@esbuild/linux-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm
-
-  "@esbuild/linux-arm@0.27.3":
-    resolution:
-      {
-        integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm
-
-  "@esbuild/linux-arm@0.27.7":
-    resolution:
-      {
-        integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm
-
-  "@esbuild/linux-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
-      }
-    os:
-      - linux
-    cpu:
-      - ia32
-
-  "@esbuild/linux-ia32@0.27.3":
-    resolution:
-      {
-        integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==,
-      }
-    os:
-      - linux
-    cpu:
-      - ia32
-
-  "@esbuild/linux-ia32@0.27.7":
-    resolution:
-      {
-        integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
-      }
-    os:
-      - linux
-    cpu:
-      - ia32
-
-  "@esbuild/linux-loong64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-loong64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-loong64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-mips64el@0.25.12":
-    resolution:
-      {
-        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-mips64el@0.27.3":
-    resolution:
-      {
-        integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-mips64el@0.27.7":
-    resolution:
-      {
-        integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
-      }
-    os:
-      - linux
-    cpu:
-      - ppc64
-
-  "@esbuild/linux-ppc64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==,
-      }
-    os:
-      - linux
-    cpu:
-      - ppc64
-
-  "@esbuild/linux-ppc64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - ppc64
-
-  "@esbuild/linux-riscv64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-riscv64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-riscv64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@esbuild/linux-s390x@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
-      }
-    os:
-      - linux
-    cpu:
-      - s390x
-
-  "@esbuild/linux-s390x@0.27.3":
-    resolution:
-      {
-        integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==,
-      }
-    os:
-      - linux
-    cpu:
-      - s390x
-
-  "@esbuild/linux-s390x@0.27.7":
-    resolution:
-      {
-        integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
-      }
-    os:
-      - linux
-    cpu:
-      - s390x
-
-  "@esbuild/linux-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@esbuild/linux-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@esbuild/linux-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@esbuild/netbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@esbuild/netbsd-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@esbuild/netbsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@esbuild/netbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
-      }
-    os:
-      - none
-    cpu:
-      - x64
-
-  "@esbuild/netbsd-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==,
-      }
-    os:
-      - none
-    cpu:
-      - x64
-
-  "@esbuild/netbsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
-      }
-    os:
-      - none
-    cpu:
-      - x64
-
-  "@esbuild/openbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - arm64
-
-  "@esbuild/openbsd-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - arm64
-
-  "@esbuild/openbsd-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - arm64
-
-  "@esbuild/openbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - x64
-
-  "@esbuild/openbsd-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - x64
-
-  "@esbuild/openbsd-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - x64
-
-  "@esbuild/openharmony-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@esbuild/openharmony-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@esbuild/openharmony-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@esbuild/sunos-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
-      }
-    os:
-      - sunos
-    cpu:
-      - x64
-
-  "@esbuild/sunos-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==,
-      }
-    os:
-      - sunos
-    cpu:
-      - x64
-
-  "@esbuild/sunos-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
-      }
-    os:
-      - sunos
-    cpu:
-      - x64
-
-  "@esbuild/win32-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
-      }
-    os:
-      - win32
-    cpu:
-      - arm64
-
-  "@esbuild/win32-arm64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==,
-      }
-    os:
-      - win32
-    cpu:
-      - arm64
-
-  "@esbuild/win32-arm64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
-      }
-    os:
-      - win32
-    cpu:
-      - arm64
-
-  "@esbuild/win32-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
-      }
-    os:
-      - win32
-    cpu:
-      - ia32
-
-  "@esbuild/win32-ia32@0.27.3":
-    resolution:
-      {
-        integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==,
-      }
-    os:
-      - win32
-    cpu:
-      - ia32
-
-  "@esbuild/win32-ia32@0.27.7":
-    resolution:
-      {
-        integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
-      }
-    os:
-      - win32
-    cpu:
-      - ia32
-
-  "@esbuild/win32-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-      }
-    os:
-      - win32
-    cpu:
-      - x64
-
-  "@esbuild/win32-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==,
-      }
+    - arm64
+
+  '@cloudflare/workerd-linux-64@1.20260511.1':
+    resolution: {integrity: sha512-5ZV6SHjU7WSsb9pRPSssckLJgDI5xemv7XpKWM023hMv9Q3jb4ZpkZEeIOGt2Q46E4/fcxfnXeQbL1nukDIpLg==}
+    engines: {node: '>=16'}
     os:
-      - win32
+    - linux
     cpu:
-      - x64
-
-  "@esbuild/win32-x64@0.27.7":
-    resolution:
-      {
-        integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
-      }
+    - x64
+
+  '@cloudflare/workerd-linux-arm64@1.20260511.1':
+    resolution: {integrity: sha512-BG8rVZZCqTvnwOMPuh+cjt/VbZ3QchxXaBOlfromw+zLQoblSHJorMPZ/JY4/phV7RoP8gB2C84bBPcahvZUnQ==}
+    engines: {node: '>=16'}
     os:
-      - win32
+    - linux
     cpu:
-      - x64
-
-  "@img/colour@1.1.0":
-    resolution:
-      {
-        integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
-      }
-
-  "@img/sharp-darwin-arm64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==,
-      }
+    - arm64
+
+  '@cloudflare/workerd-windows-64@1.20260511.1':
+    resolution: {integrity: sha512-tGEyfKFArBL0NdqmABqzsIK1vmHdshkdFzCAUo1j6LqYsEpgJWCzvqwX9IpNHEc/AAm0UtPOLhLKhz1DA7HQLA==}
+    engines: {node: '>=16'}
     os:
-      - darwin
+    - win32
     cpu:
-      - arm64
-
-  "@img/sharp-darwin-x64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==,
-      }
+    - x64
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     os:
-      - darwin
+    - darwin
     cpu:
-      - x64
-
-  "@img/sharp-libvips-darwin-arm64@1.2.4":
-    resolution:
-      {
-        integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
-      }
+    - arm64
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     os:
-      - darwin
+    - darwin
     cpu:
-      - arm64
-
-  "@img/sharp-libvips-darwin-x64@1.2.4":
-    resolution:
-      {
-        integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==,
-      }
+    - arm64
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     os:
-      - darwin
+    - linux
     cpu:
-      - x64
-
-  "@img/sharp-libvips-linux-arm64@1.2.4":
-    resolution:
-      {
-        integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
-      }
+    - arm64
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     os:
-      - linux
+    - linux
     cpu:
-      - arm64
-
-  "@img/sharp-libvips-linux-arm@1.2.4":
-    resolution:
-      {
-        integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==,
-      }
+    - arm64
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     os:
-      - linux
+    - linux
     cpu:
-      - arm
-
-  "@img/sharp-libvips-linux-ppc64@1.2.4":
-    resolution:
-      {
-        integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==,
-      }
+    - x64
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     os:
-      - linux
+    - linux
     cpu:
-      - ppc64
-
-  "@img/sharp-libvips-linux-riscv64@1.2.4":
-    resolution:
-      {
-        integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==,
-      }
+    - x64
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     os:
-      - linux
+    - win32
     cpu:
-      - none
-
-  "@img/sharp-libvips-linux-s390x@1.2.4":
-    resolution:
-      {
-        integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
-      }
+    - arm64
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     os:
-      - linux
+    - win32
     cpu:
-      - s390x
-
-  "@img/sharp-libvips-linux-x64@1.2.4":
-    resolution:
-      {
-        integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==,
-      }
+    - arm64
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     os:
-      - linux
+    - win32
     cpu:
-      - x64
-
-  "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
-    resolution:
-      {
-        integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==,
-      }
+    - x64
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     os:
-      - linux
+    - win32
     cpu:
-      - arm64
-
-  "@img/sharp-libvips-linuxmusl-x64@1.2.4":
-    resolution:
-      {
-        integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==,
-      }
+    - x64
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     os:
-      - linux
+    - darwin
     cpu:
-      - x64
-
-  "@img/sharp-linux-arm64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==,
-      }
+    - arm64
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     os:
-      - linux
+    - darwin
     cpu:
-      - arm64
-
-  "@img/sharp-linux-arm@0.34.5":
-    resolution:
-      {
-        integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==,
-      }
+    - arm64
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     os:
-      - linux
+    - linux
     cpu:
-      - arm
-
-  "@img/sharp-linux-ppc64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==,
-      }
+    - arm64
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     os:
-      - linux
+    - linux
     cpu:
-      - ppc64
-
-  "@img/sharp-linux-riscv64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==,
-      }
+    - x64
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     os:
-      - linux
+    - linux
     cpu:
-      - none
-
-  "@img/sharp-linux-s390x@0.34.5":
-    resolution:
-      {
-        integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==,
-      }
+    - arm64
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     os:
-      - linux
+    - linux
     cpu:
-      - s390x
-
-  "@img/sharp-linux-x64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==,
-      }
+    - x64
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     os:
-      - linux
+    - linux
     cpu:
-      - x64
-
-  "@img/sharp-linuxmusl-arm64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==,
-      }
+    - arm64
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     os:
-      - linux
+    - linux
     cpu:
-      - arm64
-
-  "@img/sharp-linuxmusl-x64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==,
-      }
+    - x64
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     os:
-      - linux
+    - linux
     cpu:
-      - x64
-
-  "@img/sharp-wasm32@0.34.5":
-    resolution:
-      {
-        integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==,
-      }
-    cpu:
-      - none
-
-  "@img/sharp-win32-arm64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==,
-      }
+    - arm64
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     os:
-      - win32
+    - linux
     cpu:
-      - arm64
-
-  "@img/sharp-win32-ia32@0.34.5":
-    resolution:
-      {
-        integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==,
-      }
+    - x64
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     os:
-      - win32
+    - win32
     cpu:
-      - ia32
-
-  "@img/sharp-win32-x64@0.34.5":
-    resolution:
-      {
-        integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==,
-      }
+    - arm64
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     os:
-      - win32
+    - win32
     cpu:
-      - x64
-
-  "@isaacs/cliui@9.0.0":
-    resolution:
-      {
-        integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==,
-      }
-
-  "@jest/schemas@29.6.3":
-    resolution:
-      {
-        integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==,
-      }
-
-  "@jest/types@29.6.3":
-    resolution:
-      {
-        integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==,
-      }
-
-  "@jridgewell/gen-mapping@0.3.13":
-    resolution:
-      {
-        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
-      }
-
-  "@jridgewell/remapping@2.3.5":
-    resolution:
-      {
-        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
-      }
-
-  "@jridgewell/resolve-uri@3.1.2":
-    resolution:
-      {
-        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-      }
-
-  "@jridgewell/sourcemap-codec@1.5.5":
-    resolution:
-      {
-        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
-      }
-
-  "@jridgewell/trace-mapping@0.3.31":
-    resolution:
-      {
-        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
-      }
-
-  "@jridgewell/trace-mapping@0.3.9":
-    resolution:
-      {
-        integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==,
-      }
-
-  "@lingui/babel-plugin-extract-messages@5.9.4":
-    resolution:
-      {
-        integrity: sha512-sFH5lufIBCOLwjM2hyByMIi7gaGjAPhU7md8XMQYgcEjUVtzjBQvZ9APGDdDQ5BB8xRDyqF2kvaJpJvWZu19zA==,
-      }
-
-  "@lingui/babel-plugin-lingui-macro@5.9.4":
-    resolution:
-      {
-        integrity: sha512-Gj+H48MQWY6rV40TBVG7U91/KETznbXOJpJsf8U4merBRPZgOMCy6VuWZGy1i+YJZJF/LiberlsCCEiiPbBRqg==,
-      }
-    peerDependencies:
-      babel-plugin-macros: 2 || 3
-    peerDependenciesMeta:
-      babel-plugin-macros:
-        optional: true
-
-  "@lingui/babel-plugin-lingui-macro@6.0.1":
-    resolution:
-      {
-        integrity: sha512-ZVsi04ZeqkvOfLn+fVZPEv6//SKHvrJlD+T0oJWDdymMKQVGsuFUSHFq3eFBpKilPMzYSCCj0wHgmljdUQionw==,
-      }
-
-  "@lingui/cli@5.9.4":
-    resolution:
-      {
-        integrity: sha512-0QAsZCWu6PZhxYmeQfoa6cJbNRRsTkeNQ1jTow/GzBYpFlO9iXw8dCG5cBh5pHHjzjoX3koxiKyUTFyLBmKNiQ==,
-      }
+    - x64
+
+  '@jest/schemas@29.6.3':
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+
+  '@jest/types@29.6.3':
+    resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@lingui/babel-plugin-extract-messages@6.0.1':
+    resolution: {integrity: sha512-E9quPJxYZFz2f1t8lRyPILWKrqrUI32EYBQMjC9CcneKh9ZLtvm7K1IAM+tPMYW5BDDqlXIVr8XHhGrkv/3OSA==}
+    engines: {node: '>=22.19.0'}
+
+  '@lingui/babel-plugin-lingui-macro@6.0.1':
+    resolution: {integrity: sha512-ZVsi04ZeqkvOfLn+fVZPEv6//SKHvrJlD+T0oJWDdymMKQVGsuFUSHFq3eFBpKilPMzYSCCj0wHgmljdUQionw==}
+
+  '@lingui/cli@6.0.1':
+    resolution: {integrity: sha512-xojK0f0JjgcZArNU4m3vydhG+ngQOxbovV8wDav3TT1R8PXSvKrmGfCoPffQczpbl86/0NOSdvteN8Da5MQlqg==}
+    engines: {node: '>=22.19.0'}
     hasBin: true
 
-  "@lingui/conf@5.9.4":
-    resolution:
-      {
-        integrity: sha512-crF3AQgYXg52Caz4ffJKSTXWUU/4iOGOBRnSeOkw8lsOtOYlPTaWxeSGyDTEwaGCFl6P/1aew+pvHOSCxOAyrg==,
-      }
+  '@lingui/conf@6.0.1':
+    resolution: {integrity: sha512-6NJIOTh7Pt1MXMNkUsxjA6tlKX7LB1QLh/A5H3a1SmZTSZgcbes/BvF4lEh7zAfhNIU5A5Y8PljX+n4fBGO7Hg==}
 
-  "@lingui/conf@6.0.1":
-    resolution:
-      {
-        integrity: sha512-6NJIOTh7Pt1MXMNkUsxjA6tlKX7LB1QLh/A5H3a1SmZTSZgcbes/BvF4lEh7zAfhNIU5A5Y8PljX+n4fBGO7Hg==,
-      }
-
-  "@lingui/core@5.9.4":
-    resolution:
-      {
-        integrity: sha512-MsYYc8ue/w1C8bgAbC3h4cNik64bqZ6xGxMjsVdoGQBUe+b/ij+rOEiuJXbwvlo4GXBsvsan7EzeH7sx11IsYQ==,
-      }
-    peerDependencies:
-      "@lingui/babel-plugin-lingui-macro": 5.9.4
-      babel-plugin-macros: 2 || 3
-    peerDependenciesMeta:
-      "@lingui/babel-plugin-lingui-macro":
-        optional: true
-      babel-plugin-macros:
-        optional: true
-
-  "@lingui/core@6.0.1":
-    resolution:
-      {
-        integrity: sha512-3dtvQmPv7qpu6j4SwX8h/TQu3ADujdw9/ZV3qb6OwsYa0AhBUPaydVGOEDvkNA7v/fQh6CNUc6qqZrBbDBvdHA==,
-      }
+  '@lingui/core@6.0.1':
+    resolution: {integrity: sha512-3dtvQmPv7qpu6j4SwX8h/TQu3ADujdw9/ZV3qb6OwsYa0AhBUPaydVGOEDvkNA7v/fQh6CNUc6qqZrBbDBvdHA==}
+    engines: {node: '>=22.19.0'}
     peerDependencies:
       babel-plugin-macros: 2 || 3
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
 
-  "@lingui/format-po@5.9.4":
-    resolution:
-      {
-        integrity: sha512-B+e8YF6S5EOUPF6i3gaSX69pPs/QkP6MIE97vYA48W9Lty7KFOHuYBk/YzCY9CSQaF7gW3GAI5ZsXX2+ZLVyZw==,
-      }
+  '@lingui/format-po@6.0.1':
+    resolution: {integrity: sha512-kt3naP/2kpAPJ4dwwFnkhbvR5XkGaNdbK8W6ofpIJFhY3MvGZJ9rYY0KMp++3DAaXf7r6tHq0W0To3akSDejvg==}
+    engines: {node: '>=22.19.0'}
 
-  "@lingui/message-utils@5.9.4":
-    resolution:
-      {
-        integrity: sha512-YzAVzILdsqdUqwHmryl7rfwZXRHYs6QY2wPLH5gxrV7wlieiCaskaKPeSk2SuN/gmC8im1GDrQHcwgKapFU3Sg==,
-      }
+  '@lingui/message-utils@6.0.1':
+    resolution: {integrity: sha512-cw1X5mqDODbYDkwvA9i6/4j7Ix0ptl+E9RfhBRLI2NsoLzHHX+ePryGkShFdUHYsDL+C9qkq8W0drgRVEl9LgA==}
 
-  "@lingui/message-utils@6.0.1":
-    resolution:
-      {
-        integrity: sha512-cw1X5mqDODbYDkwvA9i6/4j7Ix0ptl+E9RfhBRLI2NsoLzHHX+ePryGkShFdUHYsDL+C9qkq8W0drgRVEl9LgA==,
-      }
-
-  "@lingui/react@6.0.1":
-    resolution:
-      {
-        integrity: sha512-Pjj77gdZEINsqTvnNtHZTtU+xlgCK3lFKUd4fXMcIo8q7snkdmD8SB/EBJB28s+e5ZEcmFi5dfS4ekc5scQvPA==,
-      }
+  '@lingui/react@6.0.1':
+    resolution: {integrity: sha512-Pjj77gdZEINsqTvnNtHZTtU+xlgCK3lFKUd4fXMcIo8q7snkdmD8SB/EBJB28s+e5ZEcmFi5dfS4ekc5scQvPA==}
+    engines: {node: '>=22.19.0'}
     peerDependencies:
       babel-plugin-macros: 2 || 3
       react: ^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1505,1364 +499,634 @@ packages:
       babel-plugin-macros:
         optional: true
 
-  "@lingui/vite-plugin@5.9.4":
-    resolution:
-      {
-        integrity: sha512-qc5AFEOJjD3AIxDhCx9RZ3ELGnn0r/l3NQb4BZifz7wnYUYfbk1B2kNHCA8OMqb/sw3q36uWr3S4vORlmxPUkQ==,
-      }
+  '@lingui/vite-plugin@6.0.1':
+    resolution: {integrity: sha512-RgHkaC76p8NLj2DqA4JqC1/+pFIZWSkv4dJm/D8O+GSoJlst7WMl4h08qpPpAdTKgZpDZB8d22O6ejFohe6PTw==}
+    engines: {node: '>=22.19.0'}
     peerDependencies:
-      vite: ^3 || ^4 || ^5.0.9 || ^6 || ^7 || ^8
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@lingui/babel-plugin-lingui-macro': ^5 || ^6
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      rolldown: ^1.0.0-rc.5
+      vite: ^6.3.0 || ^7 || ^8
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@lingui/babel-plugin-lingui-macro':
+        optional: true
+      '@rolldown/plugin-babel':
+        optional: true
+      rolldown:
+        optional: true
 
-  "@mdx-js/mdx@3.1.1":
-    resolution:
-      {
-        integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==,
-      }
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
-  "@mdx-js/rollup@3.1.1":
-    resolution:
-      {
-        integrity: sha512-v8satFmBB+DqDzYohnm1u2JOvxx6Hl3pUvqzJvfs2Zk/ngZ1aRUhsWpXvwPkNeGN9c2NCm/38H29ZqXQUjf8dw==,
-      }
+  '@mdx-js/rollup@3.1.1':
+    resolution: {integrity: sha512-v8satFmBB+DqDzYohnm1u2JOvxx6Hl3pUvqzJvfs2Zk/ngZ1aRUhsWpXvwPkNeGN9c2NCm/38H29ZqXQUjf8dw==}
     peerDependencies:
-      rollup: ">=2"
+      rollup: '>=2'
 
-  "@messageformat/date-skeleton@1.1.0":
-    resolution:
-      {
-        integrity: sha512-rmGAfB1tIPER+gh3p/RgA+PVeRE/gxuQ2w4snFWPF5xtb5mbWR7Cbw7wCOftcUypbD6HVoxrVdyyghPm3WzP5A==,
-      }
+  '@messageformat/date-skeleton@1.1.0':
+    resolution: {integrity: sha512-rmGAfB1tIPER+gh3p/RgA+PVeRE/gxuQ2w4snFWPF5xtb5mbWR7Cbw7wCOftcUypbD6HVoxrVdyyghPm3WzP5A==}
 
-  "@messageformat/parser@5.1.1":
-    resolution:
-      {
-        integrity: sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==,
-      }
+  '@messageformat/parser@5.1.1':
+    resolution: {integrity: sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==}
 
-  "@napi-rs/wasm-runtime@1.1.4":
-    resolution:
-      {
-        integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==,
-      }
-    peerDependencies:
-      "@emnapi/core": ^1.7.1
-      "@emnapi/runtime": ^1.7.1
+  '@oozcitak/dom@2.0.2':
+    resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
 
-  "@oozcitak/dom@2.0.2":
-    resolution:
-      {
-        integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==,
-      }
+  '@oozcitak/infra@2.0.2':
+    resolution: {integrity: sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==}
 
-  "@oozcitak/infra@2.0.2":
-    resolution:
-      {
-        integrity: sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==,
-      }
+  '@oozcitak/url@3.0.0':
+    resolution: {integrity: sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==}
 
-  "@oozcitak/url@3.0.0":
-    resolution:
-      {
-        integrity: sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==,
-      }
+  '@oozcitak/util@10.0.0':
+    resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
 
-  "@oozcitak/util@10.0.0":
-    resolution:
-      {
-        integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==,
-      }
-
-  "@oxc-project/types@0.128.0":
-    resolution:
-      {
-        integrity: sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==,
-      }
-
-  "@oxfmt/binding-android-arm-eabi@0.48.0":
-    resolution:
-      {
-        integrity: sha512-uwqk+/KhQvBIpULD8SMM/zAafMRC/+DV/xsEQjkkIsJ/kLmEI/2bxonVowcYTiXqqZ/a0FEW8DPkZY3VvwELDA==,
-      }
+  '@oxc-parser/binding-darwin-arm64@0.120.0':
+    resolution: {integrity: sha512-xVrrbCai8R8CUIBu3CjryutQnEYhZqs1maIqDvtUCFZb8vY33H7uh9mHpL3a0JBIKoBUKjPH8+rzyAeXnS2d6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - android
+    - darwin
     cpu:
-      - arm
+    - arm64
 
-  "@oxfmt/binding-android-arm64@0.48.0":
-    resolution:
-      {
-        integrity: sha512-VUCiKuXK5+McVssgHEJdrcGK7hRJzrRb36zm9/jwzMholyYt4BgXhw5Nm1V1DX6Ce717Zi/1jk432b/tgmQgtQ==,
-      }
+  '@oxc-parser/binding-linux-arm64-gnu@0.120.0':
+    resolution: {integrity: sha512-1GgQBCcXvFMw99EPdMy+4NZ3aYyXsxjf9kbUUg8HuAy3ZBXzOry5KfFEzT9nqmgZI1cuetvApkiJBZLAPo8uaw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - android
+    - linux
     cpu:
-      - arm64
+    - arm64
 
-  "@oxfmt/binding-darwin-arm64@0.48.0":
-    resolution:
-      {
-        integrity: sha512-IkKp8rnIyQLW6Jt+6jragCbUVYSayk55lapiprLjIVvt4NczLyO/nwX2GgefLQ5iaBdfS8UEAFgCs/pLO6Cl0w==,
-      }
+  '@oxc-parser/binding-linux-arm64-musl@0.120.0':
+    resolution: {integrity: sha512-gmMQ70gsPdDBgpcErvJEoWNBr7bJooSLlvOBVBSGfOzlP5NvJ3bFvnUeZZ9d+dPrqSngtonf7nyzWUTUj/U+lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - darwin
+    - linux
     cpu:
-      - arm64
+    - arm64
 
-  "@oxfmt/binding-darwin-x64@0.48.0":
-    resolution:
-      {
-        integrity: sha512-+aFuhsGIuvnoOjXyKVHMhPKJZR1kQkAl8QyrKoMlA7yJsSTC3N0Asl53La8TChSHhW8epToQ/Q0nvLmEmfNmLg==,
-      }
+  '@oxc-parser/binding-linux-x64-gnu@0.120.0':
+    resolution: {integrity: sha512-q+5jSVZkprJCIy3dzJpApat0InJaoxQLsJuD6DkX8hrUS61z2lHQ1Fe9L2+TYbKHXCLWbL0zXe7ovkIdopBGMQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - darwin
+    - linux
     cpu:
-      - x64
+    - x64
 
-  "@oxfmt/binding-freebsd-x64@0.48.0":
-    resolution:
-      {
-        integrity: sha512-fbqzQL8FjI9gGnktI7RIo0dksDziTAYBy7xlI7jU7eID5fxLF/25fS4Xj6GydD8Y5oWHL83U4NK160QaOAxtyg==,
-      }
+  '@oxc-parser/binding-linux-x64-musl@0.120.0':
+    resolution: {integrity: sha512-D9QDDZNnH24e7X4ftSa6ar/2hCavETfW3uk0zgcMIrZNy459O5deTbWrjGzZiVrSWigGtlQwzs2McBP0QsfV1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - freebsd
+    - linux
     cpu:
-      - x64
+    - x64
 
-  "@oxfmt/binding-linux-arm-gnueabihf@0.48.0":
-    resolution:
-      {
-        integrity: sha512-hn4i0zhAyTiB3ZHjQfYUZkDvrbVkohw1S7pySWxWUoZ87HnkDoTFThj7QTxk40hNPOTUP0vHbPRNamFIv1HBJQ==,
-      }
+  '@oxc-parser/binding-win32-arm64-msvc@0.120.0':
+    resolution: {integrity: sha512-1T0HKGcsz/BKo77t7+89L8Qvu4f9DoleKWHp3C5sJEcbCjDOLx3m9m722bWZTY+hANlUEs+yjlK+lBFsA+vrVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - win32
     cpu:
-      - arm
+    - arm64
 
-  "@oxfmt/binding-linux-arm-musleabihf@0.48.0":
-    resolution:
-      {
-        integrity: sha512-R4WBD9qF3QM9hqgdAa+fBGXmquTvDUujrPQ36t2Sjk8RPOSKGHDeN7l/khr10hqbQaOq9KCgPHG9ubNET/X/RQ==,
-      }
+  '@oxc-parser/binding-win32-x64-msvc@0.120.0':
+    resolution: {integrity: sha512-ys+upfqNtSu58huAhJMBKl3XCkGzyVFBlMlGPzHeFKgpFF/OdgNs1MMf8oaJIbgMH8ZxgGF7qfue39eJohmKIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - win32
     cpu:
-      - arm
+    - x64
 
-  "@oxfmt/binding-linux-arm64-gnu@0.48.0":
-    resolution:
-      {
-        integrity: sha512-5bVdwSwlm1M8wbYCorLOxWxUBw/8tBvHYyQNIfwWVPwOJaj5vg1APSGJQVpwJfV5VNE9PSrR91UKEpoNwHhqUA==,
-      }
+  '@oxc-project/types@0.120.0':
+    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
+
+  '@oxc-project/types@0.130.0':
+    resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
+  '@oxfmt/binding-darwin-arm64@0.49.0':
+    resolution: {integrity: sha512-8x5DN9CsFfb432sHa9NyqX5XisGUdA53LPEGSdv/VniS+v4uEOR8Orv7A9QSB98Xxgp0t6r31DzQA/wpIobGqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - darwin
     cpu:
-      - arm64
+    - arm64
 
-  "@oxfmt/binding-linux-arm64-musl@0.48.0":
-    resolution:
-      {
-        integrity: sha512-vCS3Fk7gFslTqE1lUE2IlroyVV7u/9SmMA/uBqDoshuck2psGWcjW0ePyPZI3rM3+qtf2pDaMVIKMHozraifuw==,
-      }
+  '@oxfmt/binding-linux-arm64-gnu@0.49.0':
+    resolution: {integrity: sha512-JIfWenFhlzx+O8YygyZhoHFzTsdgDhxhbDRnE2iJLnnM5pWKScFvPECO2vOlA7JqJ/9S1g3uzEKuRCkHFwTjvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - linux
     cpu:
-      - arm64
+    - arm64
+    libc:
+    - glibc
 
-  "@oxfmt/binding-linux-ppc64-gnu@0.48.0":
-    resolution:
-      {
-        integrity: sha512-gKtfFfueUClXDumyoHUbymqRf7prHejOOyzJK0eIJn93GF9JBdFHdo60TM1ZBHxkEwZvjuOgHmKtneKbEOc/Eg==,
-      }
+  '@oxfmt/binding-linux-arm64-musl@0.49.0':
+    resolution: {integrity: sha512-iNzkMPG18jPkwBOZ4/HEjwqfzAjq4RrUQ0CgId/fC1ENvYD5jLVAaU/gWgpiqP1ys07kxSsSggDd1fp3E7mQHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - linux
     cpu:
-      - ppc64
+    - arm64
+    libc:
+    - musl
 
-  "@oxfmt/binding-linux-riscv64-gnu@0.48.0":
-    resolution:
-      {
-        integrity: sha512-SYt0UhOvZD/UwZz9sXq6J2uAw8o24f5VZpLB2DH01f6MevshmlgakQlZe2lwek2sZJkd07eLu7mZa0g7yeiw7Q==,
-      }
+  '@oxfmt/binding-linux-x64-gnu@0.49.0':
+    resolution: {integrity: sha512-BoC/F9xHe2y/deuBGA5Aw7bes07OD2gcL2wlpzTrfImR92vPP7S/k3LBTyspQZCNIVNdagkELcqKELwMLGIfAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - linux
     cpu:
-      - none
+    - x64
+    libc:
+    - glibc
 
-  "@oxfmt/binding-linux-riscv64-musl@0.48.0":
-    resolution:
-      {
-        integrity: sha512-JLbrwck2AopG4ud/XklZO5N+qxGC7cS7ROvXZVNfx0MCLDDL2kGOLvzuWORkVjnjAM0CMAfIMU2zNBtQbM+4dw==,
-      }
+  '@oxfmt/binding-linux-x64-musl@0.49.0':
+    resolution: {integrity: sha512-umY6jFADAo/oztFKl8D/S6vSrG6oBpEskcentiRuz42kZVU2kfDXMWCYavxyZR2bwPjqkHpcHZ6EZFiH3Qj9ZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - linux
     cpu:
-      - none
+    - x64
+    libc:
+    - musl
 
-  "@oxfmt/binding-linux-s390x-gnu@0.48.0":
-    resolution:
-      {
-        integrity: sha512-mdxt5L8OQLxkQH+JVpdC/lknZNe0lX4hlO3d8+xvw2wToo+iDrid9tiGOd5bmHfUVd5wVhrUry0qlu5vq66NkQ==,
-      }
+  '@oxfmt/binding-win32-arm64-msvc@0.49.0':
+    resolution: {integrity: sha512-38K67XR++CoFFORDd4sMFwUVAnD6msYBdGTei+qvKGrRPO6S2PbrYPNL/eQQ1RgnnxOegNba0YQwg6uRkNcw6A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - win32
     cpu:
-      - s390x
+    - arm64
 
-  "@oxfmt/binding-linux-x64-gnu@0.48.0":
-    resolution:
-      {
-        integrity: sha512-oEz1BQwMrV7OMEFx/3VPDU3n9TM0AnxpktDYXjEg5i6nTX87wo18wSfBvkl4tzAICdKtoAQAdBIl7Y7hsPlx5w==,
-      }
+  '@oxfmt/binding-win32-x64-msvc@0.49.0':
+    resolution: {integrity: sha512-gwWLwSEmBBfIK/Wh7GGd658161o4RKAvHWRaRQbJm571iQXGKfyr7UKsI1vsWvDlNLc30CxJDc8mMmCvJ/kczQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - win32
     cpu:
-      - x64
+    - x64
 
-  "@oxfmt/binding-linux-x64-musl@0.48.0":
-    resolution:
-      {
-        integrity: sha512-g2SKTTurP5mWjd8Ecait0erYqmltL4IqW1EwttM25BxM6NiTt4ubobJYMR1uox1V2QgG4UfHH10CGRvWlUixjw==,
-      }
+  '@oxlint/binding-darwin-arm64@1.64.0':
+    resolution: {integrity: sha512-U4DMLQd10gJLuoSTLSGbfv3bGjTlUNsScm9Dgb8wwBqmCzidf1pE1pXV4doGNxqwH3KtVng1AGTINA0NvkGLvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - darwin
     cpu:
-      - x64
+    - arm64
 
-  "@oxfmt/binding-openharmony-arm64@0.48.0":
-    resolution:
-      {
-        integrity: sha512-CIg24VgheEpvolHL2gQuax5qcQ602bRMHrJ9g8XsQr3iVj9aSPgopigBKuMqrXsupwkrU+RQCn5cG8PgFntR6w==,
-      }
+  '@oxlint/binding-linux-arm64-gnu@1.64.0':
+    resolution: {integrity: sha512-HpSQbubwh03mMhAdy2BYtad/fsY8vDFHDAb6bUwuCYg2VD3xCQgn6ArKcO0oZyLCheacKTv4PrF3Mfu5hgoE2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - none
+    - linux
     cpu:
-      - arm64
+    - arm64
 
-  "@oxfmt/binding-win32-arm64-msvc@0.48.0":
-    resolution:
-      {
-        integrity: sha512-zeaWkcxcEULwkGF3I/HgEvcDPN8buYDrxibBUa/IFh5Vmwyge+KpLO+hEwSovW349H0O/C0Z2kaFmEzEDm00/Q==,
-      }
+  '@oxlint/binding-linux-arm64-musl@1.64.0':
+    resolution: {integrity: sha512-00QQ0h0Y7u0G69BgiH3+ky2aaq/QvkDL6DYok8htIuJHxybiux5aQ8jwmg8qIk9wha6UagUP2BAwAzbemcJbpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - win32
+    - linux
     cpu:
-      - arm64
+    - arm64
 
-  "@oxfmt/binding-win32-ia32-msvc@0.48.0":
-    resolution:
-      {
-        integrity: sha512-yiEKnIAGvx5CyZQOlMaNlZkAbwT7/Quk0j3WLt+PR5hK+qYjPTRRJYDfD77wCBPLvEYAG41v4KG3iL0H+uxoxg==,
-      }
+  '@oxlint/binding-linux-x64-gnu@1.64.0':
+    resolution: {integrity: sha512-cR60vSd7+m+KRZ3GQGfDxWwahW5RMXg0qlGvAluZr0fTUYvw0H9N9AXAF/M/PMqgytyqvVNmBAkJG9l7U30Y1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - win32
+    - linux
     cpu:
-      - ia32
+    - x64
 
-  "@oxfmt/binding-win32-x64-msvc@0.48.0":
-    resolution:
-      {
-        integrity: sha512-GSD2+7t2UoVMV2NgxXypa4bKewflPMAjYnF0Xw9/ht82ZfafAHhb8STwrEd7wlH2PFogt5zw3WVCxYJaHUdbeQ==,
-      }
+  '@oxlint/binding-linux-x64-musl@1.64.0':
+    resolution: {integrity: sha512-2u/aPZ9pEg7HnvZPDsHxUGNnrpr4qaHi+mCgLgpt+LYRzPrS4Px4wPfkIdRdr2GvKnaYyt+XSlto0Vm5sbStTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - win32
+    - linux
     cpu:
-      - x64
+    - x64
 
-  "@oxlint/binding-android-arm-eabi@1.63.0":
-    resolution:
-      {
-        integrity: sha512-A9xLtQt7i0OA1PoB/meog6kikXI9CdwEp7ZwQqmgnpKn3G3b1orvTDy8CQ6T7w1HvDrgWGB78PkFKcWgibcTCg==,
-      }
+  '@oxlint/binding-win32-arm64-msvc@1.64.0':
+    resolution: {integrity: sha512-r/cNKBFieONoVu2bb1KkVouq9W+edDUgHumXJGphCRRj+U0xaD4nanrw8ZOqo0IsutPkEM4vCcGBpak6x5aXMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - android
+    - win32
     cpu:
-      - arm
+    - arm64
 
-  "@oxlint/binding-android-arm64@1.63.0":
-    resolution:
-      {
-        integrity: sha512-SQo+ZMvdR9l3CxZp5W5gFNxSiDxclY6lOzzNpKYLF8asESpm3Pwumx0gER5T7aHLF1/2BAAtLD3DiDkdgy4V1A==,
-      }
+  '@oxlint/binding-win32-x64-msvc@1.64.0':
+    resolution: {integrity: sha512-9CBR+LO0JVST87fNTzzNxS5I29jIUO5gxT9i9+M3SDHHALElj9sY1Prf12tad3vIRC6OD7Ehtvvh+sn13vSwHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - android
+    - win32
     cpu:
-      - arm64
+    - x64
 
-  "@oxlint/binding-darwin-arm64@1.63.0":
-    resolution:
-      {
-        integrity: sha512-6W82XjJDTmMnjg30427l0dufpnyLoq7wEukKdM6/g2VIybRVuQiBVh43EA4b+UxZ3+tLcKm+Or/pXGNgLCEU8g==,
-      }
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@rolldown/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - darwin
+    - darwin
     cpu:
-      - arm64
+    - arm64
 
-  "@oxlint/binding-darwin-x64@1.63.0":
-    resolution:
-      {
-        integrity: sha512-CnWd/YCuVG5W1BYkjJEVbJG11o526O9qAwBEQM+nh8K19CRFUkFdROXCyYkGmroHEYQe4vgQ6+lh3550Lp35Xw==,
-      }
+  '@rolldown/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - darwin
+    - linux
     cpu:
-      - x64
+    - arm64
 
-  "@oxlint/binding-freebsd-x64@1.63.0":
-    resolution:
-      {
-        integrity: sha512-a4eZAqrmtajqcxfdAzC+l7g3PaE3V8hpAYqqeD3fTxLXOMFdK3eNTZrU80n4dDEVm0JXy1aL5PqvqWldBl6zYA==,
-      }
+  '@rolldown/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - freebsd
+    - linux
     cpu:
-      - x64
+    - arm64
 
-  "@oxlint/binding-linux-arm-gnueabihf@1.63.0":
-    resolution:
-      {
-        integrity: sha512-tYUtU9TdbU3uXF5D62g5zXJ13iniFGhXQx5vp9cyEjGdbSAY3VdFBSaldYvyoDmgMZ0ZYuwQP1Y4t2Fhejwa0w==,
-      }
+  '@rolldown/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - linux
     cpu:
-      - arm
+    - x64
 
-  "@oxlint/binding-linux-arm-musleabihf@1.63.0":
-    resolution:
-      {
-        integrity: sha512-I5r3twFf776UZg9dmRo2xbrKt00tTkORXEVe0ctg4vdTkQvJAjiCHxnbAU2HL1AiJ9cqADA76MAliuilsAWnvg==,
-      }
+  '@rolldown/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - linux
     cpu:
-      - arm
+    - x64
 
-  "@oxlint/binding-linux-arm64-gnu@1.63.0":
-    resolution:
-      {
-        integrity: sha512-t7ltUkg6FFh4b564QyGir8xIj/QZbXu8FlcRkcyW9+ztr/mfRHlvUOFd95pJCXi9s/L5DrUeWWgpXRS+V+6igQ==,
-      }
+  '@rolldown/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - win32
     cpu:
-      - arm64
+    - arm64
 
-  "@oxlint/binding-linux-arm64-musl@1.63.0":
-    resolution:
-      {
-        integrity: sha512-Q5mmZy/XWjuYFUuQyYjOvZ5U/JkKEwnpir6hGxhh6HcdP0V/BKxLo8dqkfF/t7r7AguB17dfS/8+go5AQDRR6g==,
-      }
+  '@rolldown/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     os:
-      - linux
+    - win32
     cpu:
-      - arm64
+    - x64
 
-  "@oxlint/binding-linux-ppc64-gnu@1.63.0":
-    resolution:
-      {
-        integrity: sha512-uBGtuZ0TzLB4x5wVa82HGNvYqY8buwDhyCnCP0R0gkk9szqVsP0MeTtD5HX7EsEuFIt+aYmYxuxeVxs3nTSwtQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - ppc64
+  '@rolldown/pluginutils@1.0.0-beta.40':
+    resolution: {integrity: sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==}
 
-  "@oxlint/binding-linux-riscv64-gnu@1.63.0":
-    resolution:
-      {
-        integrity: sha512-h4s6FwxE+9MeA181o0dnDwHP32Y/bG8EiB/vrD6Ib+AMt6haigDc/0bUtI/sLmQDBMJnUfaCmtSSrEAqjtEVrA==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  "@oxlint/binding-linux-riscv64-musl@1.63.0":
-    resolution:
-      {
-        integrity: sha512-2EaNcCBR8Mcjl5ARtuN3BdEpVkX7KpjSjMGZ/mJMIeaXgTtdz5ytg2VwygMSStA/k0ixfvZFoZOfjDEcouV5vQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@oxlint/binding-linux-s390x-gnu@1.63.0":
-    resolution:
-      {
-        integrity: sha512-p4hlf/fd7TrYYl3QrWWD0GocqJefwMu3cHQhmi2FvEB/YOvFb5DZN3SMBaPi7B1TM5DeypkEtrVib674q1KKPg==,
-      }
-    os:
-      - linux
-    cpu:
-      - s390x
-
-  "@oxlint/binding-linux-x64-gnu@1.63.0":
-    resolution:
-      {
-        integrity: sha512-Vgq9rkRVcPcjbcH+ihYTfpeR7vCXfqpd+z5ItTGc0yYUV59L5ceHYN1iV4H9bKGV7Rn5hkVc7x3mSvHegduENA==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@oxlint/binding-linux-x64-musl@1.63.0":
-    resolution:
-      {
-        integrity: sha512-3/Lkq/ncooA61rorrC+ZQed1Bc4VpGj+WnGsp58zmxKgvZ2vhreu+dcVyr3mX8NUpq7mfZ4gDDTou/yrF1Pd7A==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@oxlint/binding-openharmony-arm64@1.63.0":
-    resolution:
-      {
-        integrity: sha512-0/EdD/6hDkx5Mfd769PTjvEM8mZ/6Dfukp1dBCL/2PjlIVGEtYdNZyok6ChqYPsT9JcFnlQnUeQzO0/1L/oC9w==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@oxlint/binding-win32-arm64-msvc@1.63.0":
-    resolution:
-      {
-        integrity: sha512-wb0CUkN8ngwPiRQBjD1Cj0LsHeNvm+Xt6YBHDMtj2DVQVD6Oj8Ri7g6BD+KICf6LaBqZlmzOvy6nF9E/8yyGOg==,
-      }
-    os:
-      - win32
-    cpu:
-      - arm64
-
-  "@oxlint/binding-win32-ia32-msvc@1.63.0":
-    resolution:
-      {
-        integrity: sha512-BX5iq+ovdNlVYhSn5qPMUIT0uwAwt2lmEnCnzK+Gkhw4DovIvhGb96OFhV8yzQNUnQxn/xGkOR+X+BLrLDNm8w==,
-      }
-    os:
-      - win32
-    cpu:
-      - ia32
-
-  "@oxlint/binding-win32-x64-msvc@1.63.0":
-    resolution:
-      {
-        integrity: sha512-QeN/WELOfsXMeYwxvfgQrl6CbVftYUCZsGXHjXQd5Trccm8+i4gmtxaOui4xbJQaiDlviF8F3yLSBloQUeFsfA==,
-      }
-    os:
-      - win32
-    cpu:
-      - x64
-
-  "@poppinss/colors@4.1.6":
-    resolution:
-      {
-        integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==,
-      }
-
-  "@poppinss/dumper@0.6.5":
-    resolution:
-      {
-        integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==,
-      }
-
-  "@poppinss/exception@1.2.3":
-    resolution:
-      {
-        integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==,
-      }
-
-  "@rolldown/binding-android-arm64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==,
-      }
-    os:
-      - android
-    cpu:
-      - arm64
-
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==,
-      }
-    os:
-      - darwin
-    cpu:
-      - arm64
-
-  "@rolldown/binding-darwin-x64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==,
-      }
-    os:
-      - darwin
-    cpu:
-      - x64
-
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - x64
-
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm
-
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm64
-
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm64
-
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==,
-      }
-    os:
-      - linux
-    cpu:
-      - ppc64
-
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==,
-      }
-    os:
-      - linux
-    cpu:
-      - s390x
-
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==,
-      }
-    cpu:
-      - none
-
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==,
-      }
-    os:
-      - win32
-    cpu:
-      - arm64
-
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==,
-      }
-    os:
-      - win32
-    cpu:
-      - x64
-
-  "@rolldown/pluginutils@1.0.0-beta.40":
-    resolution:
-      {
-        integrity: sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==,
-      }
-
-  "@rolldown/pluginutils@1.0.0-rc.18":
-    resolution:
-      {
-        integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==,
-      }
-
-  "@rolldown/pluginutils@1.0.0-rc.7":
-    resolution:
-      {
-        integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==,
-      }
-
-  "@rollup/pluginutils@5.3.0":
-    resolution:
-      {
-        integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==,
-      }
+  '@rollup/pluginutils@5.3.0':
+    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     peerDependencies:
       rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
 
-  "@rollup/rollup-android-arm-eabi@4.60.1":
-    resolution:
-      {
-        integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==,
-      }
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
     os:
-      - android
+    - darwin
     cpu:
-      - arm
+    - arm64
 
-  "@rollup/rollup-android-arm64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==,
-      }
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     os:
-      - android
+    - linux
     cpu:
-      - arm64
+    - arm64
 
-  "@rollup/rollup-darwin-arm64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==,
-      }
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     os:
-      - darwin
+    - linux
     cpu:
-      - arm64
+    - arm64
 
-  "@rollup/rollup-darwin-x64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==,
-      }
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     os:
-      - darwin
+    - linux
     cpu:
-      - x64
+    - x64
 
-  "@rollup/rollup-freebsd-arm64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==,
-      }
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     os:
-      - freebsd
+    - linux
     cpu:
-      - arm64
+    - x64
 
-  "@rollup/rollup-freebsd-x64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==,
-      }
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
     os:
-      - freebsd
+    - win32
     cpu:
-      - x64
+    - arm64
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.60.1":
-    resolution:
-      {
-        integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==,
-      }
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
     os:
-      - linux
+    - win32
     cpu:
-      - arm
+    - x64
 
-  "@rollup/rollup-linux-arm-musleabihf@4.60.1":
-    resolution:
-      {
-        integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==,
-      }
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     os:
-      - linux
+    - win32
     cpu:
-      - arm
+    - x64
 
-  "@rollup/rollup-linux-arm64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm64
+  '@sinclair/typebox@0.27.10':
+    resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
-  "@rollup/rollup-linux-arm64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm64
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
 
-  "@rollup/rollup-linux-loong64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@rollup/rollup-linux-loong64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@rollup/rollup-linux-ppc64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==,
-      }
-    os:
-      - linux
-    cpu:
-      - ppc64
-
-  "@rollup/rollup-linux-ppc64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==,
-      }
-    os:
-      - linux
-    cpu:
-      - ppc64
-
-  "@rollup/rollup-linux-riscv64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@rollup/rollup-linux-riscv64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==,
-      }
-    os:
-      - linux
-    cpu:
-      - none
-
-  "@rollup/rollup-linux-s390x-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - s390x
-
-  "@rollup/rollup-linux-x64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@rollup/rollup-linux-x64-musl@4.60.1":
-    resolution:
-      {
-        integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@rollup/rollup-openbsd-x64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - x64
-
-  "@rollup/rollup-openharmony-arm64@4.60.1":
-    resolution:
-      {
-        integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==,
-      }
-    os:
-      - none
-    cpu:
-      - arm64
-
-  "@rollup/rollup-win32-arm64-msvc@4.60.1":
-    resolution:
-      {
-        integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==,
-      }
-    os:
-      - win32
-    cpu:
-      - arm64
-
-  "@rollup/rollup-win32-ia32-msvc@4.60.1":
-    resolution:
-      {
-        integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==,
-      }
-    os:
-      - win32
-    cpu:
-      - ia32
-
-  "@rollup/rollup-win32-x64-gnu@4.60.1":
-    resolution:
-      {
-        integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==,
-      }
-    os:
-      - win32
-    cpu:
-      - x64
-
-  "@rollup/rollup-win32-x64-msvc@4.60.1":
-    resolution:
-      {
-        integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==,
-      }
-    os:
-      - win32
-    cpu:
-      - x64
-
-  "@sinclair/typebox@0.27.10":
-    resolution:
-      {
-        integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==,
-      }
-
-  "@sindresorhus/is@7.2.0":
-    resolution:
-      {
-        integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==,
-      }
-
-  "@solid-primitives/event-listener@2.4.5":
-    resolution:
-      {
-        integrity: sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==,
-      }
+  '@solid-primitives/event-listener@2.4.5':
+    resolution: {integrity: sha512-nwRV558mIabl4yVAhZKY8cb6G+O1F0M6Z75ttTu5hk+SxdOnKSGj+eetDIu7Oax1P138ZdUU01qnBPR8rnxaEA==}
     peerDependencies:
       solid-js: ^1.6.12
 
-  "@solid-primitives/keyboard@1.3.5":
-    resolution:
-      {
-        integrity: sha512-sav+l+PL+74z3yaftVs7qd8c2SXkqzuxPOVibUe5wYMt+U5Hxp3V3XCPgBPN2I6cANjvoFtz0NiU8uHVLdi9FQ==,
-      }
+  '@solid-primitives/keyboard@1.3.5':
+    resolution: {integrity: sha512-sav+l+PL+74z3yaftVs7qd8c2SXkqzuxPOVibUe5wYMt+U5Hxp3V3XCPgBPN2I6cANjvoFtz0NiU8uHVLdi9FQ==}
     peerDependencies:
       solid-js: ^1.6.12
 
-  "@solid-primitives/resize-observer@2.1.5":
-    resolution:
-      {
-        integrity: sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw==,
-      }
+  '@solid-primitives/resize-observer@2.1.5':
+    resolution: {integrity: sha512-AiyTknKcNBaKHbcSMuxtSNM8FjIuiSuFyFghdD0TcCMU9hKi9EmsC5pjfjDwxE+5EueB1a+T/34PLRI5vbBbKw==}
     peerDependencies:
       solid-js: ^1.6.12
 
-  "@solid-primitives/rootless@1.5.3":
-    resolution:
-      {
-        integrity: sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA==,
-      }
+  '@solid-primitives/rootless@1.5.3':
+    resolution: {integrity: sha512-N8cIDAHbWcLahNRLr0knAAQvXyEdEMoAZvIMZKmhNb1mlx9e2UOv9BRD5YNwQUJwbNoYVhhLwFOEOcVXFx0HqA==}
     peerDependencies:
       solid-js: ^1.6.12
 
-  "@solid-primitives/static-store@0.1.3":
-    resolution:
-      {
-        integrity: sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ==,
-      }
+  '@solid-primitives/static-store@0.1.3':
+    resolution: {integrity: sha512-uxez7SXnr5GiRnzqO2IEDjOJRIXaG+0LZLBizmUA1FwSi+hrpuMzVBwyk70m4prcl8X6FDDXUl9O8hSq8wHbBQ==}
     peerDependencies:
       solid-js: ^1.6.12
 
-  "@solid-primitives/utils@6.4.0":
-    resolution:
-      {
-        integrity: sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==,
-      }
+  '@solid-primitives/utils@6.4.0':
+    resolution: {integrity: sha512-AeGTBg8Wtkh/0s+evyLtP8piQoS4wyqqQaAFs2HJcFMMjYAtUgo+ZPduRXLjPlqKVc2ejeR544oeqpbn8Egn8A==}
     peerDependencies:
       solid-js: ^1.6.12
 
-  "@speed-highlight/core@1.2.15":
-    resolution:
-      {
-        integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==,
-      }
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
-  "@tailwindcss/node@4.3.0":
-    resolution:
-      {
-        integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==,
-      }
+  '@tailwindcss/node@4.3.0':
+    resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
-  "@tailwindcss/oxide-android-arm64@4.3.0":
-    resolution:
-      {
-        integrity: sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==,
-      }
+  '@tailwindcss/oxide-darwin-arm64@4.3.0':
+    resolution: {integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==}
     os:
-      - android
+    - darwin
     cpu:
-      - arm64
+    - arm64
 
-  "@tailwindcss/oxide-darwin-arm64@4.3.0":
-    resolution:
-      {
-        integrity: sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==,
-      }
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0':
+    resolution: {integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==}
     os:
-      - darwin
+    - linux
     cpu:
-      - arm64
+    - arm64
 
-  "@tailwindcss/oxide-darwin-x64@4.3.0":
-    resolution:
-      {
-        integrity: sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==,
-      }
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
+    resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     os:
-      - darwin
+    - linux
     cpu:
-      - x64
+    - arm64
 
-  "@tailwindcss/oxide-freebsd-x64@4.3.0":
-    resolution:
-      {
-        integrity: sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==,
-      }
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
+    resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     os:
-      - freebsd
+    - linux
     cpu:
-      - x64
+    - x64
 
-  "@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0":
-    resolution:
-      {
-        integrity: sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==,
-      }
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0':
+    resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     os:
-      - linux
+    - linux
     cpu:
-      - arm
+    - x64
 
-  "@tailwindcss/oxide-linux-arm64-gnu@4.3.0":
-    resolution:
-      {
-        integrity: sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==,
-      }
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0':
+    resolution: {integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==}
     os:
-      - linux
+    - win32
     cpu:
-      - arm64
+    - arm64
 
-  "@tailwindcss/oxide-linux-arm64-musl@4.3.0":
-    resolution:
-      {
-        integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==,
-      }
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0':
+    resolution: {integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==}
     os:
-      - linux
+    - win32
     cpu:
-      - arm64
+    - x64
 
-  "@tailwindcss/oxide-linux-x64-gnu@4.3.0":
-    resolution:
-      {
-        integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
+  '@tailwindcss/oxide@4.3.0':
+    resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
 
-  "@tailwindcss/oxide-linux-x64-musl@4.3.0":
-    resolution:
-      {
-        integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==,
-      }
-    os:
-      - linux
-    cpu:
-      - x64
-
-  "@tailwindcss/oxide-wasm32-wasi@4.3.0":
-    resolution:
-      {
-        integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==,
-      }
-    cpu:
-      - none
-
-  "@tailwindcss/oxide-win32-arm64-msvc@4.3.0":
-    resolution:
-      {
-        integrity: sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==,
-      }
-    os:
-      - win32
-    cpu:
-      - arm64
-
-  "@tailwindcss/oxide-win32-x64-msvc@4.3.0":
-    resolution:
-      {
-        integrity: sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==,
-      }
-    os:
-      - win32
-    cpu:
-      - x64
-
-  "@tailwindcss/oxide@4.3.0":
-    resolution:
-      {
-        integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==,
-      }
-
-  "@tailwindcss/typography@0.5.19":
-    resolution:
-      {
-        integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==,
-      }
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
     peerDependencies:
-      tailwindcss: ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
-  "@tailwindcss/vite@4.3.0":
-    resolution:
-      {
-        integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==,
-      }
+  '@tailwindcss/vite@4.3.0':
+    resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  "@tanstack/devtools-client@0.0.6":
-    resolution:
-      {
-        integrity: sha512-f85ZJXJnDIFOoykG/BFIixuAevJovCvJF391LPs6YjBAPhGYC50NWlx1y4iF/UmK5/cCMx+/JqI5SBOz7FanQQ==,
-      }
+  '@tanstack/devtools-client@0.0.6':
+    resolution: {integrity: sha512-f85ZJXJnDIFOoykG/BFIixuAevJovCvJF391LPs6YjBAPhGYC50NWlx1y4iF/UmK5/cCMx+/JqI5SBOz7FanQQ==}
 
-  "@tanstack/devtools-event-bus@0.4.1":
-    resolution:
-      {
-        integrity: sha512-cNnJ89Q021Zf883rlbBTfsaxTfi2r73/qejGtyTa7ksErF3hyDyAq1aTbo5crK9dAL7zSHh9viKY1BtMls1QOA==,
-      }
+  '@tanstack/devtools-event-bus@0.4.1':
+    resolution: {integrity: sha512-cNnJ89Q021Zf883rlbBTfsaxTfi2r73/qejGtyTa7ksErF3hyDyAq1aTbo5crK9dAL7zSHh9viKY1BtMls1QOA==}
 
-  "@tanstack/devtools-event-client@0.4.3":
-    resolution:
-      {
-        integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==,
-      }
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
     hasBin: true
 
-  "@tanstack/devtools-ui@0.5.1":
-    resolution:
-      {
-        integrity: sha512-T9JjAdqMSnxsVO6AQykD5vhxPF4iFLKtbYxee/bU3OLlk446F5C1220GdCmhDSz7y4lx+m8AvIS0bq6zzvdDUA==,
-      }
+  '@tanstack/devtools-ui@0.5.2':
+    resolution: {integrity: sha512-GtaMk8kaGZ9ZdR8Pu5RAfcse/ZrxzH/xsAIFtHMapLs2VMqSPFfb1NvIDO1MAAfUcub8Ix8XKQEP0uYSPzoFKw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      solid-js: '>=1.9.7'
 
-  "@tanstack/devtools-vite@0.6.0":
-    resolution:
-      {
-        integrity: sha512-h0r0ct7zlrgjkhmn4QW6wRjgUXd4JMs+r7gtx+BXo9f5H9Y+jtUdtvC0rnZcPto6gw/9yMUq7yOmMK5qDWRExg==,
-      }
+  '@tanstack/devtools-vite@0.7.0':
+    resolution: {integrity: sha512-VXki7K+Xwnpo3IKdNSWGe7YOvtZv33YlulGqaQ+YCpeQhYg8JFuxP50BXibDoRLj5EOX4r21Hs7COdxbRHXkTw==}
+    engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  "@tanstack/devtools@0.11.2":
-    resolution:
-      {
-        integrity: sha512-K8+tsBx+ptTLqqd4dOF10B6laj1g+XYImqYZL9n0jBINGaT+sOf17PKV9pbBt8kdbZeIGsHaJ5OZWCyZoHqN4A==,
-      }
+  '@tanstack/devtools@0.12.2':
+    resolution: {integrity: sha512-Xdl8pLzoDUvXaclQ0poY36WAPx0jEHk8vqUFd8FYFUm1BMshtB7RnTgD1HE9jCAXODxqw9I0gXBiUZLK3o3+Bw==}
+    engines: {node: '>=18'}
     hasBin: true
-
-  "@tanstack/history@1.161.6":
-    resolution:
-      {
-        integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==,
-      }
-
-  "@tanstack/query-core@5.100.8":
-    resolution:
-      {
-        integrity: sha512-ceYwSFOqjPwET5TA6IOYxzxlGc0ekyH/gfOtWkP0PX43rzX9bxW48Iuw8KAduKCToi4rJAQ6nRy2kAe8gszdmg==,
-      }
-
-  "@tanstack/react-devtools@0.10.2":
-    resolution:
-      {
-        integrity: sha512-1BmZyxOrI5SqmRJ5MgkYZNNdnlLsJxQRI2YgorrAvcF2MxK6x5RcuStvD8+YlXoMw3JtNukPxoITirKAnKYDQA==,
-      }
     peerDependencies:
-      "@types/react": ">=16.8"
-      "@types/react-dom": ">=16.8"
-      react: ">=16.8"
-      react-dom: ">=16.8"
+      solid-js: '>=1.9.7'
 
-  "@tanstack/react-query@5.100.8":
-    resolution:
-      {
-        integrity: sha512-iNNEekixXU5vtAGKKZX2lx3jTooG5yNY+kv0wSgEdEYG0Mj0JM5bcuQtC35ZAP3nDopT6jciUK3xeX65U7AnfA==,
-      }
+  '@tanstack/history@1.161.6':
+    resolution: {integrity: sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==}
+
+  '@tanstack/query-core@5.100.8':
+    resolution: {integrity: sha512-ceYwSFOqjPwET5TA6IOYxzxlGc0ekyH/gfOtWkP0PX43rzX9bxW48Iuw8KAduKCToi4rJAQ6nRy2kAe8gszdmg==}
+
+  '@tanstack/react-devtools@0.10.5':
+    resolution: {integrity: sha512-orVsRJ7oAXFb7oyafQCgx9YuK44jpILh5T/ddYuxAsolNfN5DZBr5/NLrWErD7HCGIzvYzg1TZI4sPxmiKvtvA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      '@types/react-dom': '>=16.8'
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/react-query@5.100.8':
+    resolution: {integrity: sha512-iNNEekixXU5vtAGKKZX2lx3jTooG5yNY+kv0wSgEdEYG0Mj0JM5bcuQtC35ZAP3nDopT6jciUK3xeX65U7AnfA==}
     peerDependencies:
       react: ^18 || ^19
 
-  "@tanstack/react-router-devtools@1.166.13":
-    resolution:
-      {
-        integrity: sha512-6yKRFFJrEEOiGp5RAAuGCYsl81M4XAhJmLcu9PKj+HZle4A3dsP60lwHoqQYWHMK9nKKFkdXR+D8qxzxqtQbEA==,
-      }
+  '@tanstack/react-router-devtools@1.166.13':
+    resolution: {integrity: sha512-6yKRFFJrEEOiGp5RAAuGCYsl81M4XAhJmLcu9PKj+HZle4A3dsP60lwHoqQYWHMK9nKKFkdXR+D8qxzxqtQbEA==}
+    engines: {node: '>=20.19'}
     peerDependencies:
-      "@tanstack/react-router": ^1.168.15
-      "@tanstack/router-core": ^1.168.11
-      react: ">=18.0.0 || >=19.0.0"
-      react-dom: ">=18.0.0 || >=19.0.0"
+      '@tanstack/react-router': ^1.168.15
+      '@tanstack/router-core': ^1.168.11
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
     peerDependenciesMeta:
-      "@tanstack/router-core":
+      '@tanstack/router-core':
         optional: true
 
-  "@tanstack/react-router-ssr-query@1.166.12":
-    resolution:
-      {
-        integrity: sha512-yDUIoEh+PimAcWmk/2BE0EkI8TwLVeToNzoIuwahmTtBUR+ptZPWbtiPjudO8JZ0BhT3odHtuOn1eBOK0/4NAQ==,
-      }
+  '@tanstack/react-router-ssr-query@1.166.12':
+    resolution: {integrity: sha512-yDUIoEh+PimAcWmk/2BE0EkI8TwLVeToNzoIuwahmTtBUR+ptZPWbtiPjudO8JZ0BhT3odHtuOn1eBOK0/4NAQ==}
+    engines: {node: '>=20.19'}
     peerDependencies:
-      "@tanstack/query-core": ">=5.90.0"
-      "@tanstack/react-query": ">=5.90.0"
-      "@tanstack/react-router": ">=1.127.0"
-      react: ">=18.0.0 || >=19.0.0"
-      react-dom: ">=18.0.0 || >=19.0.0"
+      '@tanstack/query-core': '>=5.90.0'
+      '@tanstack/react-query': '>=5.90.0'
+      '@tanstack/react-router': '>=1.127.0'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
 
-  "@tanstack/react-router@1.169.1":
-    resolution:
-      {
-        integrity: sha512-MBtQKSvac3OCcsSa6oBpDrrN90IV47I6Gtv05NxhbFVh+gVjtqvs6HSU4XM9+y5sHZPgS+35eArflX4vM8GEnQ==,
-      }
+  '@tanstack/react-router@1.169.2':
+    resolution: {integrity: sha512-OJM7Kguc7ERnweaNRWsyWgIKcl3z23rD1B4jaxjzd9RGdnzpt2HfrWa9rggbT0Hfzhfo4D2ZmsfoTme035tniQ==}
+    engines: {node: '>=20.19'}
     peerDependencies:
-      react: ">=18.0.0 || >=19.0.0"
-      react-dom: ">=18.0.0 || >=19.0.0"
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
 
-  "@tanstack/react-start-client@1.166.47":
-    resolution:
-      {
-        integrity: sha512-9g2BRXcB8ODsytbJpxxJfk73hAPrHAlb3UHSeelDnufh9c147hgjdhQj8gG9/KwXXLCS6AwAZMEbB/Mwn62qWA==,
-      }
+  '@tanstack/react-start-client@1.166.48':
+    resolution: {integrity: sha512-6fqwCwe6v+Nvtdf6vg6gxs/0gCXyZEHF18EslNeG/kca2wnXYFuXRhqGJjJaEgMk3WF4IE9mUgFuBSAOY3P7nQ==}
+    engines: {node: '>=22.12.0'}
     peerDependencies:
-      react: ">=18.0.0 || >=19.0.0"
-      react-dom: ">=18.0.0 || >=19.0.0"
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
 
-  "@tanstack/react-start-rsc@0.0.38":
-    resolution:
-      {
-        integrity: sha512-y5brWXm9GaPNmgX5siKSrvEZvO0+7RVdxBHjEKkyDkVFX/GQ9OYI2obL6trcfw7e8OrDwX7tjBrgwTAIT49Lxw==,
-      }
+  '@tanstack/react-start-rsc@0.0.44':
+    resolution: {integrity: sha512-5iYUWSBjTwJbV8bTLJHZ5dHm8c/79J6spxPlKsjt9/R0mQaQQjLVNMpv5CrOZ2vPTaZx1ALoGdSWP4WdPcuKRA==}
+    engines: {node: '>=22.12.0'}
     peerDependencies:
-      "@rspack/core": ">=2.0.0-0"
-      "@vitejs/plugin-rsc": ">=0.5.20"
-      react: ">=18.0.0 || >=19.0.0"
-      react-dom: ">=18.0.0 || >=19.0.0"
-      react-server-dom-rspack: ">=0.0.2"
+      '@rspack/core': '>=2.0.0-0'
+      '@vitejs/plugin-rsc': '>=0.5.20'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      react-server-dom-rspack: '>=0.0.2'
     peerDependenciesMeta:
-      "@rspack/core":
+      '@rspack/core':
         optional: true
-      "@vitejs/plugin-rsc":
+      '@vitejs/plugin-rsc':
         optional: true
       react-server-dom-rspack:
         optional: true
 
-  "@tanstack/react-start-server@1.166.48":
-    resolution:
-      {
-        integrity: sha512-0WLlS0hIsc6QE3dvP3k8tbmQYqIfd+BNkW7p9GOgdrriZRVZPLsjCTHTWMQ+pHcdf2jtrfh+HeNn2Hzggvnmow==,
-      }
+  '@tanstack/react-start-server@1.166.52':
+    resolution: {integrity: sha512-46Gx+byIndYywUtyna5h3qatHipJkPFqo/miexfuYPgeVAI6ypQzsw7wxF194H6VAP43m2q+fdLPBXStufoOGw==}
+    engines: {node: '>=22.12.0'}
     peerDependencies:
-      react: ">=18.0.0 || >=19.0.0"
-      react-dom: ">=18.0.0 || >=19.0.0"
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
 
-  "@tanstack/react-start@1.167.59":
-    resolution:
-      {
-        integrity: sha512-Cmqh+X4QHalKGbBIdVycBJWea2K77dWXVGX3VdnpRtqOUcWZrerEOyfcLkqYL3ricECSrdMua1WHzD2LNpoj9w==,
-      }
-    hasBin: true
+  '@tanstack/react-start@1.167.65':
+    resolution: {integrity: sha512-vCGga3RECeR4VpSVuXIU/+zxak5f2qdpUXdZ2yrgcwwKoYPtatdJm6zjS0Py7UOecRqLqMtSeuOjowBJ1higWQ==}
+    engines: {node: '>=22.12.0'}
     peerDependencies:
-      "@rsbuild/core": ^2.0.0
-      react: ">=18.0.0 || >=19.0.0"
-      react-dom: ">=18.0.0 || >=19.0.0"
-      vite: ">=7.0.0"
+      '@rsbuild/core': ^2.0.0
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      vite: '>=7.0.0'
     peerDependenciesMeta:
-      "@rsbuild/core":
+      '@rsbuild/core':
+        optional: true
+      '@vitejs/plugin-rsc':
         optional: true
       vite:
         optional: true
 
-  "@tanstack/react-store@0.9.3":
-    resolution:
-      {
-        integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==,
-      }
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  "@tanstack/router-core@1.168.9":
-    resolution:
-      {
-        integrity: sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g==,
-      }
-    hasBin: true
+  '@tanstack/router-core@1.169.2':
+    resolution: {integrity: sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw==}
+    engines: {node: '>=20.19'}
 
-  "@tanstack/router-core@1.169.1":
-    resolution:
-      {
-        integrity: sha512-x+2gIGKTTE1qAn7tLieGfrB5ciOviDmmi2ox9fAWUubRV+yTU5ruGFXocoCIWF+lB+SOtnHjo2E9BLSWyYoEmA==,
-      }
-    hasBin: true
-
-  "@tanstack/router-devtools-core@1.167.3":
-    resolution:
-      {
-        integrity: sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg==,
-      }
+  '@tanstack/router-devtools-core@1.167.3':
+    resolution: {integrity: sha512-fJ1VMhyQgnoashTrP763c2HRc9kofgF61L7Jb3F6eTHAmCKtGVx8BRtiFt37sr3U0P0jmaaiiSPGP6nT5JtVNg==}
     peerDependencies:
-      "@tanstack/router-core": ^1.168.11
+      '@tanstack/router-core': ^1.168.11
       csstype: ^3.0.10
     peerDependenciesMeta:
       csstype:
         optional: true
 
-  "@tanstack/router-generator@1.166.24":
-    resolution:
-      {
-        integrity: sha512-vdaGKwuH+r+DPe6R1mjk+TDDmDH6NTG7QqwxHqGEvOH4aGf9sPjhmRKNJZqQr8cPIbfp6u5lXyZ1TeDcSNMVEA==,
-      }
+  '@tanstack/router-generator@1.166.42':
+    resolution: {integrity: sha512-2qBWC0t78r6b3vI+AbnvCZcFAvbYBDlLuWZrTjQbcjUmwG3qyeQp983tJyDuj9wb5//adG1tgAGXZkJ3aDwdBg==}
+    engines: {node: '>=20.19'}
 
-  "@tanstack/router-generator@1.166.39":
-    resolution:
-      {
-        integrity: sha512-j2OW/UvpjM/DT9tHVmuhWW1k6UOezTRrPqBPZFFmIth0fY7iTPqK+Erqpo8r5yGTRGCbMvOS4sL3H2MldnIZew==,
-      }
-
-  "@tanstack/router-plugin@1.167.12":
-    resolution:
-      {
-        integrity: sha512-StEHcctCuFI5taSjO+lhR/yQ+EK63BdyYa+ne6FoNQPB3MMrOUrz2ZVnbqILRLkh2b+p2EfBKt65sgAKdKygPQ==,
-      }
-    hasBin: true
+  '@tanstack/router-plugin@1.167.35':
+    resolution: {integrity: sha512-UAScU5VAzLYVY4FML/Cbc5S5TucT4I8Ata05yozGOe4ZfepTKRffA5xWLtD2N+ov5svdv0KTX/kqlZnYPe28mA==}
+    engines: {node: '>=20.19'}
     peerDependencies:
-      "@rsbuild/core": ">=1.0.2"
-      "@tanstack/react-router": ^1.168.10
-      vite: ">=5.0.0 || >=6.0.0 || >=7.0.0"
-      vite-plugin-solid: ^2.11.10
-      webpack: ">=5.92.0"
-    peerDependenciesMeta:
-      "@rsbuild/core":
-        optional: true
-      "@tanstack/react-router":
-        optional: true
-      vite:
-        optional: true
-      vite-plugin-solid:
-        optional: true
-      webpack:
-        optional: true
-
-  "@tanstack/router-plugin@1.167.32":
-    resolution:
-      {
-        integrity: sha512-i9BA6GzUCoM20UYZ77orXzHwD5zM0OQTtLuPNbqTTSG38CvR6viRFP/d+QFo2aRNyCvun8PR7zSa49bslSggEQ==,
-      }
-    hasBin: true
-    peerDependencies:
-      "@rsbuild/core": ">=1.0.2 || ^2.0.0"
-      "@tanstack/react-router": ^1.169.1
-      vite: ">=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0"
+      '@rsbuild/core': '>=1.0.2 || ^2.0.0'
+      '@tanstack/react-router': ^1.169.2
+      vite: '>=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0'
       vite-plugin-solid: ^2.11.10 || ^3.0.0-0
-      webpack: ">=5.92.0"
+      webpack: '>=5.92.0'
     peerDependenciesMeta:
-      "@rsbuild/core":
+      '@rsbuild/core':
         optional: true
-      "@tanstack/react-router":
+      '@tanstack/react-router':
         optional: true
       vite:
         optional: true
@@ -2871,884 +1135,419 @@ packages:
       webpack:
         optional: true
 
-  "@tanstack/router-ssr-query-core@1.168.0":
-    resolution:
-      {
-        integrity: sha512-5yBUAF1d9z2kOFKoz1spvpvkMSTmRnRXEwi+bGKfrXYmt7CfHu3Pk8KUFMln67uQoKQ9VTkcd5tLkjJVrZ2/AQ==,
-      }
+  '@tanstack/router-ssr-query-core@1.168.0':
+    resolution: {integrity: sha512-5yBUAF1d9z2kOFKoz1spvpvkMSTmRnRXEwi+bGKfrXYmt7CfHu3Pk8KUFMln67uQoKQ9VTkcd5tLkjJVrZ2/AQ==}
     peerDependencies:
-      "@tanstack/query-core": ">=5.90.0"
-      "@tanstack/router-core": ">=1.127.0"
+      '@tanstack/query-core': '>=5.90.0'
+      '@tanstack/router-core': '>=1.127.0'
 
-  "@tanstack/router-utils@1.161.6":
-    resolution:
-      {
-        integrity: sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw==,
-      }
+  '@tanstack/router-utils@1.161.8':
+    resolution: {integrity: sha512-xyiLWEKjfBAVhauDSSjXxyf7s8elU6SM+V050sbkofvGmIIvkwPFtDsX7Gvwh14kBd6iCwAT+RiPvXTxAptY0Q==}
+    engines: {node: '>=20.19'}
 
-  "@tanstack/router-utils@1.161.7":
-    resolution:
-      {
-        integrity: sha512-VkY0u7ax/GD0qU6ZLLnfPC+UMxVzxRbvZp4yV4iUSXjgJZ/siAT5/QlLm9FEDJ9QDoC0VD9W7f00tKKreUI7Ng==,
-      }
+  '@tanstack/start-client-core@1.168.2':
+    resolution: {integrity: sha512-/bckv9k/yxY4VmSY2V2MeX7NBsS5uqGvdSPs5WIvW3Uv35DXPrdiumKXTNJeZRNRMtxrM+YfxQPjXLx3C7ykvg==}
+    engines: {node: '>=22.12.0'}
 
-  "@tanstack/start-client-core@1.168.1":
-    resolution:
-      {
-        integrity: sha512-P0gtOPMzHONjDP0fLL7NWJ25MWBrwxh45tMObgzKH7ziHXciB1s3eiUUjNWISr/vcPXVptppgaBVJ8IGZpR1fQ==,
-      }
-    hasBin: true
+  '@tanstack/start-fn-stubs@1.161.6':
+    resolution: {integrity: sha512-Y6QSlGiLga8cHfvxGGaonXIlt2bIUTVdH6AMjmpMp7+ANNCp+N96GQbjjhLye3JkaxDfP68x5iZA8NK4imgRig==}
 
-  "@tanstack/start-fn-stubs@1.161.6":
-    resolution:
-      {
-        integrity: sha512-Y6QSlGiLga8cHfvxGGaonXIlt2bIUTVdH6AMjmpMp7+ANNCp+N96GQbjjhLye3JkaxDfP68x5iZA8NK4imgRig==,
-      }
-
-  "@tanstack/start-plugin-core@1.169.14":
-    resolution:
-      {
-        integrity: sha512-6KLhg+A9WlSNend74oQwKk0TSDSrvGqonHK4aSwPJpt9HMdItMVV2lZWARBsB4xUpLrd+RNx5C9tjCfN00t5Ww==,
-      }
+  '@tanstack/start-plugin-core@1.169.20':
+    resolution: {integrity: sha512-MLSH5P3auFpnol1lMGQhUrpJH7+P5knzBXMnJjXG+nVOvmcYbY0JA+nQMl81kKiqfkEceAiaEdKhl8Zc5Ldolw==}
+    engines: {node: '>=22.12.0'}
     peerDependencies:
-      "@rsbuild/core": ^2.0.0
-      vite: ">=7.0.0"
+      '@rsbuild/core': ^2.0.0
+      vite: '>=7.0.0'
     peerDependenciesMeta:
-      "@rsbuild/core":
+      '@rsbuild/core':
         optional: true
       vite:
         optional: true
 
-  "@tanstack/start-server-core@1.167.26":
-    resolution:
-      {
-        integrity: sha512-rC86SiSnKjcBd9Y5hlskMBBxRhfBrXWz2IqfeGMaITXdmLfpZeGTM9nftx5T7af4h88eJxpAvijbTsWVH9wLoQ==,
-      }
+  '@tanstack/start-server-core@1.167.30':
+    resolution: {integrity: sha512-GC0PXzYYSEwfAOC2NxGXFUyYvfbSjVoqnIrzJsyInKd8xQxGEQaVdrebbyx9TV5cj7A5e7EJcWAsf3G3wRDQBw==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/start-storage-context@1.166.35':
+    resolution: {integrity: sha512-ZKDkKiorJrKwfEHjatEwRHG7EP3raJPhh6CSl4CFmHW0naIvwaW5gQcxcT8IlHtoGDLYDAjBEcSr3MZyXgqmOA==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-file-routes@1.161.7':
+    resolution: {integrity: sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ==}
     hasBin: true
 
-  "@tanstack/start-storage-context@1.166.34":
-    resolution:
-      {
-        integrity: sha512-mIre+HDvahOnUmP3vQx+x4kvUzam/uVYpCphudR/Czzi0Crfm0JyyLMNv7hHxkfqMg9aTrxYtDTZHR3isrUKhg==,
-      }
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
-  "@tanstack/store@0.9.3":
-    resolution:
-      {
-        integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==,
-      }
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
-  "@tanstack/virtual-file-routes@1.161.7":
-    resolution:
-      {
-        integrity: sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ==,
-      }
-    hasBin: true
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  "@tybys/wasm-util@0.10.1":
-    resolution:
-      {
-        integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==,
-      }
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  "@types/debug@4.1.13":
-    resolution:
-      {
-        integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
-      }
+  '@types/istanbul-lib-coverage@2.0.6':
+    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
-  "@types/estree-jsx@1.0.5":
-    resolution:
-      {
-        integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
-      }
+  '@types/istanbul-lib-report@3.0.3':
+    resolution: {integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==}
 
-  "@types/estree@1.0.8":
-    resolution:
-      {
-        integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
-      }
+  '@types/istanbul-reports@3.0.4':
+    resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
-  "@types/hast@3.0.4":
-    resolution:
-      {
-        integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
-      }
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
-  "@types/istanbul-lib-coverage@2.0.6":
-    resolution:
-      {
-        integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==,
-      }
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
-  "@types/istanbul-lib-report@3.0.3":
-    resolution:
-      {
-        integrity: sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==,
-      }
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  "@types/istanbul-reports@3.0.4":
-    resolution:
-      {
-        integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==,
-      }
+  '@types/node@25.5.2':
+    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
-  "@types/mdast@4.0.4":
-    resolution:
-      {
-        integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
-      }
-
-  "@types/mdx@2.0.13":
-    resolution:
-      {
-        integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
-      }
-
-  "@types/ms@2.1.0":
-    resolution:
-      {
-        integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
-      }
-
-  "@types/node@25.5.2":
-    resolution:
-      {
-        integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==,
-      }
-
-  "@types/react-dom@19.2.3":
-    resolution:
-      {
-        integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==,
-      }
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      "@types/react": ^19.2.0
+      '@types/react': ^19.2.0
 
-  "@types/react@19.2.14":
-    resolution:
-      {
-        integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==,
-      }
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
-  "@types/unist@2.0.11":
-    resolution:
-      {
-        integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==,
-      }
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  "@types/unist@3.0.3":
-    resolution:
-      {
-        integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
-      }
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  "@types/yargs-parser@21.0.3":
-    resolution:
-      {
-        integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==,
-      }
+  '@types/yargs-parser@21.0.3':
+    resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
-  "@types/yargs@17.0.35":
-    resolution:
-      {
-        integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==,
-      }
+  '@types/yargs@17.0.35':
+    resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  "@ungap/structured-clone@1.3.0":
-    resolution:
-      {
-        integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
-      }
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
-  "@vitejs/plugin-react@6.0.1":
-    resolution:
-      {
-        integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==,
-      }
+  '@vitejs/plugin-react@6.0.2':
+    resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
       vite: ^8.0.0
     peerDependenciesMeta:
-      "@rolldown/plugin-babel":
+      '@rolldown/plugin-babel':
         optional: true
       babel-plugin-react-compiler:
         optional: true
 
   acorn-jsx@5.3.2:
-    resolution:
-      {
-        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
-      }
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn@8.16.0:
-    resolution:
-      {
-        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
-      }
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     hasBin: true
 
   ansi-regex@5.0.1:
-    resolution:
-      {
-        integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
-      }
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
 
   ansi-styles@4.3.0:
-    resolution:
-      {
-        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
-      }
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
 
   ansi-styles@5.2.0:
-    resolution:
-      {
-        integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
-      }
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
 
   ansis@4.2.0:
-    resolution:
-      {
-        integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==,
-      }
+    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
 
   anymatch@3.1.3:
-    resolution:
-      {
-        integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
-      }
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
 
   argparse@2.0.1:
-    resolution:
-      {
-        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
-      }
-
-  ast-types@0.16.1:
-    resolution:
-      {
-        integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==,
-      }
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   astring@1.9.0:
-    resolution:
-      {
-        integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==,
-      }
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
   babel-dead-code-elimination@1.0.12:
-    resolution:
-      {
-        integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==,
-      }
+    resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
   bail@2.0.2:
-    resolution:
-      {
-        integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
-      }
-
-  balanced-match@4.0.4:
-    resolution:
-      {
-        integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
-      }
-
-  base64-js@1.5.1:
-    resolution:
-      {
-        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
-      }
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   baseline-browser-mapping@2.10.14:
-    resolution:
-      {
-        integrity: sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==,
-      }
+    resolution: {integrity: sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==}
     hasBin: true
 
   binary-extensions@2.3.0:
-    resolution:
-      {
-        integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==,
-      }
-
-  bl@4.1.0:
-    resolution:
-      {
-        integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==,
-      }
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
 
   blake3-wasm@2.1.5:
-    resolution:
-      {
-        integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==,
-      }
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
   boolbase@1.0.0:
-    resolution:
-      {
-        integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
-      }
-
-  brace-expansion@5.0.5:
-    resolution:
-      {
-        integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==,
-      }
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
   braces@3.0.3:
-    resolution:
-      {
-        integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
-      }
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
 
   browserslist@4.28.2:
-    resolution:
-      {
-        integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==,
-      }
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     hasBin: true
 
-  buffer@5.7.1:
-    resolution:
-      {
-        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
-      }
-
-  callsites@3.1.0:
-    resolution:
-      {
-        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
-      }
-
   camelcase@6.3.0:
-    resolution:
-      {
-        integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==,
-      }
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
 
   caniuse-lite@1.0.30001785:
-    resolution:
-      {
-        integrity: sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==,
-      }
+    resolution: {integrity: sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==}
 
   ccount@2.0.1:
-    resolution:
-      {
-        integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
-      }
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
   chalk@4.1.2:
-    resolution:
-      {
-        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
-      }
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
 
   chalk@5.6.2:
-    resolution:
-      {
-        integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
-      }
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
 
   character-entities-html4@2.1.0:
-    resolution:
-      {
-        integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==,
-      }
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
   character-entities-legacy@3.0.0:
-    resolution:
-      {
-        integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==,
-      }
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   character-entities@2.0.2:
-    resolution:
-      {
-        integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==,
-      }
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
   character-reference-invalid@2.0.1:
-    resolution:
-      {
-        integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
-      }
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   cheerio-select@2.1.0:
-    resolution:
-      {
-        integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==,
-      }
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
 
   cheerio@1.2.0:
-    resolution:
-      {
-        integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==,
-      }
-
-  chokidar@3.5.1:
-    resolution:
-      {
-        integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==,
-      }
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
 
   chokidar@3.6.0:
-    resolution:
-      {
-        integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
-      }
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
 
-  cli-cursor@3.1.0:
-    resolution:
-      {
-        integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==,
-      }
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
-  cli-spinners@2.9.2:
-    resolution:
-      {
-        integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==,
-      }
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
 
-  cli-table@0.3.11:
-    resolution:
-      {
-        integrity: sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==,
-      }
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
 
-  clone@1.0.4:
-    resolution:
-      {
-        integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==,
-      }
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
 
   clsx@2.1.1:
-    resolution:
-      {
-        integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==,
-      }
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
 
   collapse-white-space@2.1.0:
-    resolution:
-      {
-        integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
-      }
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
   color-convert@2.0.1:
-    resolution:
-      {
-        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
-      }
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
 
   color-name@1.1.4:
-    resolution:
-      {
-        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
-      }
-
-  colors@1.0.3:
-    resolution:
-      {
-        integrity: sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==,
-      }
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   comma-separated-tokens@2.0.3:
-    resolution:
-      {
-        integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
-      }
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@10.0.1:
-    resolution:
-      {
-        integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==,
-      }
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   convert-source-map@2.0.0:
-    resolution:
-      {
-        integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
-      }
-
-  cookie-es@2.0.1:
-    resolution:
-      {
-        integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==,
-      }
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-es@3.1.1:
-    resolution:
-      {
-        integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==,
-      }
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie@1.1.1:
-    resolution:
-      {
-        integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==,
-      }
-
-  cosmiconfig@8.3.6:
-    resolution:
-      {
-        integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==,
-      }
-    peerDependencies:
-      typescript: ">=4.9.5"
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  cross-spawn@7.0.6:
-    resolution:
-      {
-        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
-      }
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
 
   css-select@5.2.2:
-    resolution:
-      {
-        integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==,
-      }
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
   css-what@6.2.2:
-    resolution:
-      {
-        integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==,
-      }
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
 
   cssesc@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
-      }
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     hasBin: true
 
   csstype@3.2.3:
-    resolution:
-      {
-        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
-      }
-
-  date-fns@3.6.0:
-    resolution:
-      {
-        integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==,
-      }
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   dayjs@1.11.20:
-    resolution:
-      {
-        integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==,
-      }
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@4.4.3:
-    resolution:
-      {
-        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
-      }
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
 
   decode-named-character-reference@1.3.0:
-    resolution:
-      {
-        integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
-      }
-
-  defaults@1.0.4:
-    resolution:
-      {
-        integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==,
-      }
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
   dequal@2.0.3:
-    resolution:
-      {
-        integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
-      }
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
 
   detect-libc@2.1.2:
-    resolution:
-      {
-        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
-      }
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
 
   devlop@1.1.0:
-    resolution:
-      {
-        integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
-      }
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diff@8.0.4:
-    resolution:
-      {
-        integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==,
-      }
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
 
   dom-serializer@2.0.0:
-    resolution:
-      {
-        integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==,
-      }
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
   domelementtype@2.3.0:
-    resolution:
-      {
-        integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
-      }
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
   domhandler@5.0.3:
-    resolution:
-      {
-        integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==,
-      }
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
 
   domutils@3.2.2:
-    resolution:
-      {
-        integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==,
-      }
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   electron-to-chromium@1.5.331:
-    resolution:
-      {
-        integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==,
-      }
+    resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   encoding-sniffer@0.2.1:
-    resolution:
-      {
-        integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==,
-      }
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
 
   enhanced-resolve@5.21.2:
-    resolution:
-      {
-        integrity: sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==,
-      }
+    resolution: {integrity: sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==}
 
   entities@4.5.0:
-    resolution:
-      {
-        integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
-      }
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
 
   entities@6.0.1:
-    resolution:
-      {
-        integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==,
-      }
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
 
   entities@7.0.1:
-    resolution:
-      {
-        integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==,
-      }
-
-  error-ex@1.3.4:
-    resolution:
-      {
-        integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==,
-      }
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
 
   error-stack-parser-es@1.0.5:
-    resolution:
-      {
-        integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==,
-      }
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   esast-util-from-estree@2.0.0:
-    resolution:
-      {
-        integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==,
-      }
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
   esast-util-from-js@2.0.1:
-    resolution:
-      {
-        integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
-      }
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
   esbuild@0.25.12:
-    resolution:
-      {
-        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-      }
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     hasBin: true
 
   esbuild@0.27.3:
-    resolution:
-      {
-        integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==,
-      }
-    hasBin: true
-
-  esbuild@0.27.7:
-    resolution:
-      {
-        integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
-      }
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     hasBin: true
 
   escalade@3.2.0:
-    resolution:
-      {
-        integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
-      }
-
-  esm@3.2.25:
-    resolution:
-      {
-        integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==,
-      }
-
-  esprima@4.0.1:
-    resolution:
-      {
-        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
-      }
-    hasBin: true
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
 
   estree-util-attach-comments@3.0.0:
-    resolution:
-      {
-        integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==,
-      }
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
 
   estree-util-build-jsx@3.0.1:
-    resolution:
-      {
-        integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==,
-      }
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
 
   estree-util-is-identifier-name@3.0.0:
-    resolution:
-      {
-        integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==,
-      }
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
   estree-util-scope@1.0.0:
-    resolution:
-      {
-        integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==,
-      }
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
 
   estree-util-to-js@2.0.0:
-    resolution:
-      {
-        integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==,
-      }
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
 
   estree-util-visit@2.0.0:
-    resolution:
-      {
-        integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==,
-      }
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
 
   estree-walker@2.0.2:
-    resolution:
-      {
-        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
-      }
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
-    resolution:
-      {
-        integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
-      }
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   exsolve@1.0.8:
-    resolution:
-      {
-        integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==,
-      }
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
   extend@3.0.2:
-    resolution:
-      {
-        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
-      }
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fdir@6.5.0:
-    resolution:
-      {
-        integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
-      }
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
 
-  fill-range@7.1.1:
-    resolution:
-      {
-        integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
-      }
+  fetchdts@0.1.7:
+    resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
-  foreground-child@3.3.1:
-    resolution:
-      {
-        integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==,
-      }
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
 
   fsevents@2.3.3:
-    resolution:
-      {
-        integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
-      }
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     os:
-      - darwin
+    - darwin
 
   gensync@1.0.0-beta.2:
-    resolution:
-      {
-        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
-      }
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
 
-  get-tsconfig@4.13.7:
-    resolution:
-      {
-        integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==,
-      }
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   glob-parent@5.1.2:
-    resolution:
-      {
-        integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
-      }
-
-  glob@11.1.0:
-    resolution:
-      {
-        integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==,
-      }
-    hasBin: true
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
 
   goober@2.1.18:
-    resolution:
-      {
-        integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==,
-      }
+    resolution: {integrity: sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==}
     peerDependencies:
       csstype: ^3.0.10
 
   graceful-fs@4.2.11:
-    resolution:
-      {
-        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-      }
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   h3-v2@2.0.1-rc.20:
-    resolution:
-      {
-        integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==,
-      }
+    resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
     hasBin: true
     peerDependencies:
       crossws: ^0.4.1
@@ -3758,1498 +1557,706 @@ packages:
     aliasOf: h3
 
   has-flag@4.0.0:
-    resolution:
-      {
-        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-      }
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
 
   hast-util-to-estree@3.1.3:
-    resolution:
-      {
-        integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==,
-      }
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
   hast-util-to-jsx-runtime@2.3.6:
-    resolution:
-      {
-        integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==,
-      }
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
   hast-util-whitespace@3.0.0:
-    resolution:
-      {
-        integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
-      }
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   htmlparser2@10.1.0:
-    resolution:
-      {
-        integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==,
-      }
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   iconv-lite@0.6.3:
-    resolution:
-      {
-        integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==,
-      }
-
-  ieee754@1.2.1:
-    resolution:
-      {
-        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
-      }
-
-  import-fresh@3.3.1:
-    resolution:
-      {
-        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
-      }
-
-  inherits@2.0.4:
-    resolution:
-      {
-        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
-      }
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
 
   inline-style-parser@0.2.7:
-    resolution:
-      {
-        integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==,
-      }
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   is-alphabetical@2.0.1:
-    resolution:
-      {
-        integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==,
-      }
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
   is-alphanumerical@2.0.1:
-    resolution:
-      {
-        integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
-      }
-
-  is-arrayish@0.2.1:
-    resolution:
-      {
-        integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
-      }
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-binary-path@2.1.0:
-    resolution:
-      {
-        integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
-      }
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
 
   is-decimal@2.0.1:
-    resolution:
-      {
-        integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==,
-      }
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
-    resolution:
-      {
-        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
-      }
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
-    resolution:
-      {
-        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
-      }
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
 
   is-hexadecimal@2.0.1:
-    resolution:
-      {
-        integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
-      }
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
-  is-interactive@1.0.0:
-    resolution:
-      {
-        integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==,
-      }
+  is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
 
   is-number@7.0.0:
-    resolution:
-      {
-        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
-      }
-
-  is-observable@2.1.0:
-    resolution:
-      {
-        integrity: sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==,
-      }
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
 
   is-plain-obj@4.1.0:
-    resolution:
-      {
-        integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
-      }
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
 
-  is-unicode-supported@0.1.0:
-    resolution:
-      {
-        integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==,
-      }
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   isbot@5.1.37:
-    resolution:
-      {
-        integrity: sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==,
-      }
-
-  isexe@2.0.0:
-    resolution:
-      {
-        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
-      }
-
-  jackspeak@4.2.3:
-    resolution:
-      {
-        integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==,
-      }
+    resolution: {integrity: sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==}
 
   jest-get-type@29.6.3:
-    resolution:
-      {
-        integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==,
-      }
+    resolution: {integrity: sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==}
 
   jest-validate@29.7.0:
-    resolution:
-      {
-        integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==,
-      }
+    resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
 
   jiti@2.6.1:
-    resolution:
-      {
-        integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
-      }
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   js-sha256@0.10.1:
-    resolution:
-      {
-        integrity: sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==,
-      }
+    resolution: {integrity: sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==}
 
   js-tokens@4.0.0:
-    resolution:
-      {
-        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-      }
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.1.1:
-    resolution:
-      {
-        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
-      }
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   jsesc@3.1.0:
-    resolution:
-      {
-        integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
-      }
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     hasBin: true
 
-  json-parse-even-better-errors@2.3.1:
-    resolution:
-      {
-        integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
-      }
-
   json5@2.2.3:
-    resolution:
-      {
-        integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
-      }
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     hasBin: true
 
   kleur@4.1.5:
-    resolution:
-      {
-        integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==,
-      }
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
 
   launch-editor@2.13.2:
-    resolution:
-      {
-        integrity: sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==,
-      }
+    resolution: {integrity: sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==}
 
   lefthook-darwin-arm64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==,
-      }
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
     os:
-      - darwin
+    - darwin
     cpu:
-      - arm64
-
-  lefthook-darwin-x64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==,
-      }
-    os:
-      - darwin
-    cpu:
-      - x64
-
-  lefthook-freebsd-arm64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - arm64
-
-  lefthook-freebsd-x64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - x64
+    - arm64
 
   lefthook-linux-arm64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==,
-      }
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
     os:
-      - linux
+    - linux
     cpu:
-      - arm64
+    - arm64
 
   lefthook-linux-x64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==,
-      }
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
     os:
-      - linux
+    - linux
     cpu:
-      - x64
-
-  lefthook-openbsd-arm64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - arm64
-
-  lefthook-openbsd-x64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==,
-      }
-    os:
-      - openbsd
-    cpu:
-      - x64
+    - x64
 
   lefthook-windows-arm64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==,
-      }
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
     os:
-      - win32
+    - win32
     cpu:
-      - arm64
+    - arm64
 
   lefthook-windows-x64@2.1.6:
-    resolution:
-      {
-        integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==,
-      }
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
     os:
-      - win32
+    - win32
     cpu:
-      - x64
+    - x64
 
   lefthook@2.1.6:
-    resolution:
-      {
-        integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==,
-      }
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
     hasBin: true
 
   leven@3.1.0:
-    resolution:
-      {
-        integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==,
-      }
-
-  lightningcss-android-arm64@1.32.0:
-    resolution:
-      {
-        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
-      }
-    os:
-      - android
-    cpu:
-      - arm64
+    resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
 
   lightningcss-darwin-arm64@1.32.0:
-    resolution:
-      {
-        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
-      }
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     os:
-      - darwin
+    - darwin
     cpu:
-      - arm64
-
-  lightningcss-darwin-x64@1.32.0:
-    resolution:
-      {
-        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
-      }
-    os:
-      - darwin
-    cpu:
-      - x64
-
-  lightningcss-freebsd-x64@1.32.0:
-    resolution:
-      {
-        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
-      }
-    os:
-      - freebsd
-    cpu:
-      - x64
-
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution:
-      {
-        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
-      }
-    os:
-      - linux
-    cpu:
-      - arm
+    - arm64
 
   lightningcss-linux-arm64-gnu@1.32.0:
-    resolution:
-      {
-        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
-      }
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     os:
-      - linux
+    - linux
     cpu:
-      - arm64
+    - arm64
 
   lightningcss-linux-arm64-musl@1.32.0:
-    resolution:
-      {
-        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
-      }
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     os:
-      - linux
+    - linux
     cpu:
-      - arm64
+    - arm64
 
   lightningcss-linux-x64-gnu@1.32.0:
-    resolution:
-      {
-        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
-      }
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     os:
-      - linux
+    - linux
     cpu:
-      - x64
+    - x64
 
   lightningcss-linux-x64-musl@1.32.0:
-    resolution:
-      {
-        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
-      }
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     os:
-      - linux
+    - linux
     cpu:
-      - x64
+    - x64
 
   lightningcss-win32-arm64-msvc@1.32.0:
-    resolution:
-      {
-        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
-      }
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     os:
-      - win32
+    - win32
     cpu:
-      - arm64
+    - arm64
 
   lightningcss-win32-x64-msvc@1.32.0:
-    resolution:
-      {
-        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
-      }
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
     os:
-      - win32
+    - win32
     cpu:
-      - x64
+    - x64
 
   lightningcss@1.32.0:
-    resolution:
-      {
-        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
-      }
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
 
   lilconfig@3.1.3:
-    resolution:
-      {
-        integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
-      }
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
 
-  lines-and-columns@1.2.4:
-    resolution:
-      {
-        integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
-      }
-
-  log-symbols@4.1.0:
-    resolution:
-      {
-        integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==,
-      }
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
 
   longest-streak@3.1.0:
-    resolution:
-      {
-        integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
-      }
-
-  lru-cache@11.2.7:
-    resolution:
-      {
-        integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==,
-      }
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   lru-cache@5.1.1:
-    resolution:
-      {
-        integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
-      }
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.21:
-    resolution:
-      {
-        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
-      }
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   markdown-extensions@2.0.0:
-    resolution:
-      {
-        integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==,
-      }
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
 
   mdast-util-from-markdown@2.0.3:
-    resolution:
-      {
-        integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
-      }
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
   mdast-util-mdx-expression@2.0.1:
-    resolution:
-      {
-        integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==,
-      }
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
   mdast-util-mdx-jsx@3.2.0:
-    resolution:
-      {
-        integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==,
-      }
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
 
   mdast-util-mdx@3.0.0:
-    resolution:
-      {
-        integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==,
-      }
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
 
   mdast-util-mdxjs-esm@2.0.1:
-    resolution:
-      {
-        integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
-      }
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
-    resolution:
-      {
-        integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==,
-      }
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
   mdast-util-to-hast@13.2.1:
-    resolution:
-      {
-        integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==,
-      }
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
   mdast-util-to-markdown@2.1.2:
-    resolution:
-      {
-        integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==,
-      }
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
 
   mdast-util-to-string@4.0.0:
-    resolution:
-      {
-        integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
-      }
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
 
   micromark-core-commonmark@2.0.3:
-    resolution:
-      {
-        integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
-      }
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
 
   micromark-extension-mdx-expression@3.0.1:
-    resolution:
-      {
-        integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==,
-      }
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
 
   micromark-extension-mdx-jsx@3.0.2:
-    resolution:
-      {
-        integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==,
-      }
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
 
   micromark-extension-mdx-md@2.0.0:
-    resolution:
-      {
-        integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==,
-      }
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
 
   micromark-extension-mdxjs-esm@3.0.0:
-    resolution:
-      {
-        integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==,
-      }
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
 
   micromark-extension-mdxjs@3.0.0:
-    resolution:
-      {
-        integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==,
-      }
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
 
   micromark-factory-destination@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==,
-      }
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
 
   micromark-factory-label@2.0.1:
-    resolution:
-      {
-        integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==,
-      }
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
 
   micromark-factory-mdx-expression@2.0.3:
-    resolution:
-      {
-        integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==,
-      }
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
 
   micromark-factory-space@2.0.1:
-    resolution:
-      {
-        integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==,
-      }
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
 
   micromark-factory-title@2.0.1:
-    resolution:
-      {
-        integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==,
-      }
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
 
   micromark-factory-whitespace@2.0.1:
-    resolution:
-      {
-        integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==,
-      }
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
 
   micromark-util-character@2.1.1:
-    resolution:
-      {
-        integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==,
-      }
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
 
   micromark-util-chunked@2.0.1:
-    resolution:
-      {
-        integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==,
-      }
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
 
   micromark-util-classify-character@2.0.1:
-    resolution:
-      {
-        integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==,
-      }
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
 
   micromark-util-combine-extensions@2.0.1:
-    resolution:
-      {
-        integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==,
-      }
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
 
   micromark-util-decode-numeric-character-reference@2.0.2:
-    resolution:
-      {
-        integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==,
-      }
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
 
   micromark-util-decode-string@2.0.1:
-    resolution:
-      {
-        integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==,
-      }
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
 
   micromark-util-encode@2.0.1:
-    resolution:
-      {
-        integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==,
-      }
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
 
   micromark-util-events-to-acorn@2.0.3:
-    resolution:
-      {
-        integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==,
-      }
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
 
   micromark-util-html-tag-name@2.0.1:
-    resolution:
-      {
-        integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==,
-      }
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
 
   micromark-util-normalize-identifier@2.0.1:
-    resolution:
-      {
-        integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==,
-      }
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
 
   micromark-util-resolve-all@2.0.1:
-    resolution:
-      {
-        integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==,
-      }
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
 
   micromark-util-sanitize-uri@2.0.1:
-    resolution:
-      {
-        integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==,
-      }
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
 
   micromark-util-subtokenize@2.1.0:
-    resolution:
-      {
-        integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==,
-      }
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
 
   micromark-util-symbol@2.0.1:
-    resolution:
-      {
-        integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==,
-      }
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
 
   micromark-util-types@2.0.2:
-    resolution:
-      {
-        integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==,
-      }
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromark@4.0.2:
-    resolution:
-      {
-        integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==,
-      }
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
-    resolution:
-      {
-        integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
-      }
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
 
-  mimic-fn@2.1.0:
-    resolution:
-      {
-        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
-      }
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
-  miniflare@4.20260507.1:
-    resolution:
-      {
-        integrity: sha512-PSXBiLExTdZ4UGO/raKCHQauUpYL7F880ZRB7j0+78Rv8h7TsdN2E/iEDK9sK2Y+SPQ5wJSeAa+rDeVKoZZoEw==,
-      }
+  miniflare@4.20260511.0:
+    resolution: {integrity: sha512-GjTfjtdrDb4LTUcA1S/iz/YKMvSxlbgAfgXpyhM1PQV/xzUYRpKWayq3R1vOQg53Y/g0epaBFaZLA2QbnS/meA==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
 
-  minimatch@10.2.5:
-    resolution:
-      {
-        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
-      }
-
-  minipass@7.1.3:
-    resolution:
-      {
-        integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==,
-      }
-
   moo@0.5.3:
-    resolution:
-      {
-        integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==,
-      }
+    resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
 
   ms@2.1.3:
-    resolution:
-      {
-        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-      }
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-      }
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     hasBin: true
 
   node-releases@2.0.37:
-    resolution:
-      {
-        integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==,
-      }
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
   normalize-path@3.0.0:
-    resolution:
-      {
-        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
-      }
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
 
   nth-check@2.1.1:
-    resolution:
-      {
-        integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
-      }
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  observable-fns@0.6.1:
-    resolution:
-      {
-        integrity: sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg==,
-      }
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
-  onetime@5.1.2:
-    resolution:
-      {
-        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
-      }
+  ora@9.4.0:
+    resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
+    engines: {node: '>=20'}
 
-  ora@5.4.1:
-    resolution:
-      {
-        integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==,
-      }
+  oxc-parser@0.120.0:
+    resolution: {integrity: sha512-WyPWZlcIm+Fkte63FGfgFB8mAAk33aH9h5N9lphXVOHSXEBFFsmYdOBedVKly363aWABjZdaj/m9lBfEY4wt+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
-  oxfmt@0.48.0:
-    resolution:
-      {
-        integrity: sha512-AVaLh+7XeGx+R1zfFV+f6VV61nT2MWVJXVUDhbTm5LBWGyNt64xAyh3NYYyjeY2WykNt9AvqSQLPHcbWquYF9g==,
-      }
-    hasBin: true
-
-  oxlint@1.63.0:
-    resolution:
-      {
-        integrity: sha512-9TGXetdjgIHOJ9OiReomP7nnrMkV9HxC1xM2ramJSLQpzxjsAJtQwa4wqkJN2f/uCrqZuJseFuSlWDdvcruveg==,
-      }
+  oxfmt@0.49.0:
+    resolution: {integrity: sha512-IAHFMdlJSWe+oAr65dx22UvjCtV9DBMisAuLnKpDqMQrctzCkGnj3QRwNHm0d+uwSWPalsDF8ZYLz9rh6nH2IQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: ">=0.22.1"
+      svelte: ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  oxlint@1.64.0:
+    resolution: {integrity: sha512-Star3SNpWPeWFPw7kRXIhXUSn6fdiAl25q15CQzH/9WaOtG6e9CWTc25vNZOCr4PE1yEP1GtKJKIKglhj3OmEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
 
-  package-json-from-dist@1.0.1:
-    resolution:
-      {
-        integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==,
-      }
-
-  parent-module@1.0.1:
-    resolution:
-      {
-        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
-      }
-
   parse-entities@4.0.2:
-    resolution:
-      {
-        integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==,
-      }
-
-  parse-json@5.2.0:
-    resolution:
-      {
-        integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==,
-      }
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
-    resolution:
-      {
-        integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==,
-      }
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
   parse5-parser-stream@7.1.2:
-    resolution:
-      {
-        integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==,
-      }
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
 
   parse5@7.3.0:
-    resolution:
-      {
-        integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
-      }
-
-  path-key@3.1.1:
-    resolution:
-      {
-        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
-      }
-
-  path-scurry@2.0.2:
-    resolution:
-      {
-        integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==,
-      }
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-to-regexp@6.3.0:
-    resolution:
-      {
-        integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==,
-      }
-
-  path-type@4.0.0:
-    resolution:
-      {
-        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
-      }
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
-    resolution:
-      {
-        integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
-      }
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
-    resolution:
-      {
-        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
-      }
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.2:
-    resolution:
-      {
-        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
-      }
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
 
   picomatch@4.0.4:
-    resolution:
-      {
-        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
-      }
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
 
   pofile@1.1.4:
-    resolution:
-      {
-        integrity: sha512-r6Q21sKsY1AjTVVjOuU02VYKVNQGJNQHjTIvs4dEbeuuYfxgYk/DGD2mqqq4RDaVkwdSq0VEtmQUOPe/wH8X3g==,
-      }
+    resolution: {integrity: sha512-r6Q21sKsY1AjTVVjOuU02VYKVNQGJNQHjTIvs4dEbeuuYfxgYk/DGD2mqqq4RDaVkwdSq0VEtmQUOPe/wH8X3g==}
 
   postcss-selector-parser@6.0.10:
-    resolution:
-      {
-        integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==,
-      }
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
 
   postcss@8.5.14:
-    resolution:
-      {
-        integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==,
-      }
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
 
   prettier@3.8.1:
-    resolution:
-      {
-        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
-      }
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     hasBin: true
 
   pretty-format@29.7.0:
-    resolution:
-      {
-        integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==,
-      }
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
 
   property-information@7.1.0:
-    resolution:
-      {
-        integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
-      }
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
   pseudolocale@2.2.0:
-    resolution:
-      {
-        integrity: sha512-O+D2eU7fO9wVLqrohvt9V/9fwMadnJQ4jxwiK+LeNEqhMx8JYx4xQHkArDCJFAdPPOp/pQq6z5L37eBvAoc8jw==,
-      }
+    resolution: {integrity: sha512-O+D2eU7fO9wVLqrohvt9V/9fwMadnJQ4jxwiK+LeNEqhMx8JYx4xQHkArDCJFAdPPOp/pQq6z5L37eBvAoc8jw==}
     hasBin: true
 
-  react-dom@19.2.4:
-    resolution:
-      {
-        integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==,
-      }
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
-      react: ^19.2.4
+      react: ^19.2.6
 
   react-is@18.3.1:
-    resolution:
-      {
-        integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==,
-      }
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react@19.2.4:
-    resolution:
-      {
-        integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==,
-      }
-
-  readable-stream@3.6.2:
-    resolution:
-      {
-        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
-      }
-
-  readdirp@3.5.0:
-    resolution:
-      {
-        integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==,
-      }
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
 
   readdirp@3.6.0:
-    resolution:
-      {
-        integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
-      }
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
 
-  recast@0.23.11:
-    resolution:
-      {
-        integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==,
-      }
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
 
   recma-build-jsx@1.0.0:
-    resolution:
-      {
-        integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==,
-      }
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
   recma-jsx@1.0.1:
-    resolution:
-      {
-        integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==,
-      }
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   recma-parse@1.0.0:
-    resolution:
-      {
-        integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==,
-      }
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
 
   recma-stringify@1.0.0:
-    resolution:
-      {
-        integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==,
-      }
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
 
   rehype-recma@1.0.0:
-    resolution:
-      {
-        integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==,
-      }
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
 
   remark-mdx@3.1.1:
-    resolution:
-      {
-        integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==,
-      }
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
 
   remark-parse@11.0.0:
-    resolution:
-      {
-        integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==,
-      }
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
 
   remark-rehype@11.1.2:
-    resolution:
-      {
-        integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==,
-      }
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
-  resolve-from@4.0.0:
-    resolution:
-      {
-        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
-      }
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
 
-  resolve-pkg-maps@1.0.0:
-    resolution:
-      {
-        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
-      }
-
-  restore-cursor@3.1.0:
-    resolution:
-      {
-        integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==,
-      }
-
-  rolldown@1.0.0-rc.18:
-    resolution:
-      {
-        integrity: sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==,
-      }
+  rolldown@1.0.1:
+    resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
   rollup@4.60.1:
-    resolution:
-      {
-        integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==,
-      }
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
     hasBin: true
 
   rou3@0.8.1:
-    resolution:
-      {
-        integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==,
-      }
-
-  safe-buffer@5.2.1:
-    resolution:
-      {
-        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
-      }
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
   safer-buffer@2.1.2:
-    resolution:
-      {
-        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
-      }
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   scheduler@0.27.0:
-    resolution:
-      {
-        integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
-      }
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
-    resolution:
-      {
-        integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
-      }
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   semver@7.8.0:
-    resolution:
-      {
-        integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==,
-      }
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     hasBin: true
 
   seroval-plugins@1.5.2:
-    resolution:
-      {
-        integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==,
-      }
+    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
     peerDependencies:
       seroval: ^1.0
 
   seroval@1.5.2:
-    resolution:
-      {
-        integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==,
-      }
+    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
 
   sharp@0.34.5:
-    resolution:
-      {
-        integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==,
-      }
-
-  shebang-command@2.0.0:
-    resolution:
-      {
-        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
-      }
-
-  shebang-regex@3.0.0:
-    resolution:
-      {
-        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
-      }
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
 
   shell-quote@1.8.3:
-    resolution:
-      {
-        integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==,
-      }
-
-  signal-exit@3.0.7:
-    resolution:
-      {
-        integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
-      }
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
 
   signal-exit@4.1.0:
-    resolution:
-      {
-        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
-      }
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
 
   solid-js@1.9.12:
-    resolution:
-      {
-        integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==,
-      }
+    resolution: {integrity: sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw==}
 
   source-map-js@1.2.1:
-    resolution:
-      {
-        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
-      }
-
-  source-map@0.6.1:
-    resolution:
-      {
-        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
-      }
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
 
   source-map@0.7.6:
-    resolution:
-      {
-        integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
-      }
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
 
   space-separated-tokens@2.0.2:
-    resolution:
-      {
-        integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
-      }
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
   srvx@0.11.15:
-    resolution:
-      {
-        integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==,
-      }
+    resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
     hasBin: true
 
-  string_decoder@1.3.0:
-    resolution:
-      {
-        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
-      }
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
+    engines: {node: '>=18'}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
 
   stringify-entities@4.0.4:
-    resolution:
-      {
-        integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
-      }
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
-    resolution:
-      {
-        integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
-      }
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   style-to-js@1.1.21:
-    resolution:
-      {
-        integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==,
-      }
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
   style-to-object@1.0.14:
-    resolution:
-      {
-        integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
-      }
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   supports-color@10.2.2:
-    resolution:
-      {
-        integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==,
-      }
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
 
   supports-color@7.2.0:
-    resolution:
-      {
-        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-      }
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
 
   tailwindcss-logical@4.2.0:
-    resolution:
-      {
-        integrity: sha512-G+7NFU8xiMczeaykFRvaDbfbpqvFWv05YG6RtS2klW1wvTRkUs96P/e+Zy/Qse6y0HL8tLQ+da8M7trDfu12sw==,
-      }
+    resolution: {integrity: sha512-G+7NFU8xiMczeaykFRvaDbfbpqvFWv05YG6RtS2klW1wvTRkUs96P/e+Zy/Qse6y0HL8tLQ+da8M7trDfu12sw==}
     peerDependencies:
-      tailwindcss: ">=4.0.0"
+      tailwindcss: '>=4.0.0'
 
   tailwindcss@4.3.0:
-    resolution:
-      {
-        integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==,
-      }
+    resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
 
   tapable@2.3.3:
-    resolution:
-      {
-        integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==,
-      }
-
-  threads@1.7.0:
-    resolution:
-      {
-        integrity: sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==,
-      }
-
-  tiny-invariant@1.3.3:
-    resolution:
-      {
-        integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==,
-      }
-
-  tiny-worker@2.3.0:
-    resolution:
-      {
-        integrity: sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==,
-      }
-
-  tinyglobby@0.2.15:
-    resolution:
-      {
-        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
-      }
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
 
   tinyglobby@0.2.16:
-    resolution:
-      {
-        integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==,
-      }
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
 
   tinypool@2.1.0:
-    resolution:
-      {
-        integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==,
-      }
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
 
   to-regex-range@5.0.1:
-    resolution:
-      {
-        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
-      }
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
 
   trim-lines@3.0.1:
-    resolution:
-      {
-        integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==,
-      }
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   trough@2.2.0:
-    resolution:
-      {
-        integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
-      }
-
-  tslib@2.8.1:
-    resolution:
-      {
-        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
-      }
-
-  tsx@4.21.0:
-    resolution:
-      {
-        integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==,
-      }
-    hasBin: true
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   typescript@6.0.3:
-    resolution:
-      {
-        integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==,
-      }
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   ufo@1.6.3:
-    resolution:
-      {
-        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
-      }
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   undici-types@7.18.2:
-    resolution:
-      {
-        integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
-      }
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici@7.24.7:
-    resolution:
-      {
-        integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==,
-      }
+    resolution: {integrity: sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==}
 
   undici@7.24.8:
-    resolution:
-      {
-        integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==,
-      }
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
 
   unenv@2.0.0-rc.24:
-    resolution:
-      {
-        integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==,
-      }
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unified@11.0.5:
-    resolution:
-      {
-        integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
-      }
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
   unist-util-is@6.0.1:
-    resolution:
-      {
-        integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==,
-      }
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position-from-estree@2.0.0:
-    resolution:
-      {
-        integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==,
-      }
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
 
   unist-util-position@5.0.0:
-    resolution:
-      {
-        integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==,
-      }
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
 
   unist-util-stringify-position@4.0.0:
-    resolution:
-      {
-        integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
-      }
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
 
   unist-util-visit-parents@6.0.2:
-    resolution:
-      {
-        integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==,
-      }
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
 
   unist-util-visit@5.1.0:
-    resolution:
-      {
-        integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
-      }
-
-  unplugin@2.3.11:
-    resolution:
-      {
-        integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==,
-      }
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   unplugin@3.0.0:
-    resolution:
-      {
-        integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==,
-      }
+    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
 
   update-browserslist-db@1.2.3:
-    resolution:
-      {
-        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
-      }
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
-      browserslist: ">= 4.21.0"
+      browserslist: '>= 4.21.0'
 
   use-sync-external-store@1.6.0:
-    resolution:
-      {
-        integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
-      }
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
-    resolution:
-      {
-        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
-      }
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vfile-message@4.0.3:
-    resolution:
-      {
-        integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==,
-      }
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
   vfile@6.0.3:
-    resolution:
-      {
-        integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
-      }
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@8.0.11:
-    resolution:
-      {
-        integrity: sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==,
-      }
+  vite@8.0.13:
+    resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      "@types/node": ^20.19.0 || >=22.12.0
-      "@vitejs/devtools": ^0.1.18
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
       esbuild: ^0.27.0 || ^0.28.0
-      jiti: ">=1.21.0"
+      jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
-      stylus: ">=0.54.8"
+      stylus: '>=0.54.8'
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
-      "@types/node":
+      '@types/node':
         optional: true
-      "@vitejs/devtools":
+      '@vitejs/devtools':
         optional: true
       esbuild:
         optional: true
@@ -5273,74 +2280,42 @@ packages:
         optional: true
 
   vitefu@1.1.3:
-    resolution:
-      {
-        integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==,
-      }
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
         optional: true
 
-  wcwidth@1.0.1:
-    resolution:
-      {
-        integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==,
-      }
-
   webpack-virtual-modules@0.6.2:
-    resolution:
-      {
-        integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==,
-      }
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
   whatwg-encoding@3.1.1:
-    resolution:
-      {
-        integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==,
-      }
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
 
   whatwg-mimetype@4.0.0:
-    resolution:
-      {
-        integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==,
-      }
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
 
-  which@2.0.2:
-    resolution:
-      {
-        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
-      }
+  workerd@1.20260511.1:
+    resolution: {integrity: sha512-ecODCw4iWIuvuXdfy358zNpGPuO8k2WLMTaM1TKd+DuR6IF/oItVuvjf4BNhiKXlhIYBbD5GQ0gGHBY/IxSJVA==}
+    engines: {node: '>=16'}
     hasBin: true
 
-  workerd@1.20260507.1:
-    resolution:
-      {
-        integrity: sha512-z7JhsFSe6+X1b5fUHaVpo15VM1IRMJiLofEkq8iKdCo+Veqc+FUg5lIsuz8NwePxuSKrXtO4ZQpGkQLbPVXFhg==,
-      }
-    hasBin: true
-
-  wrangler@4.90.0:
-    resolution:
-      {
-        integrity: sha512-bmNIykl59TfCUn5xQgU7IWylSsPx3LQaPLMSAq2VQHt89CBrcj9qXQ0eYfjBCWA5XTBVgten391evt7xxtXwcA==,
-      }
+  wrangler@4.91.0:
+    resolution: {integrity: sha512-dFzhAd2/DpaHGRrQMQkL8F6AKmjzK2hfbhyTJ+5dcZS6jdl9KG8oxO5oAflIdlsRYnrOzxRxQnvIqwewIq1FXA==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      "@cloudflare/workers-types": ^4.20260507.1
+      '@cloudflare/workers-types': ^4.20260511.1
     peerDependenciesMeta:
-      "@cloudflare/workers-types":
+      '@cloudflare/workers-types':
         optional: true
 
   ws@8.18.0:
-    resolution:
-      {
-        integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==,
-      }
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ">=5.0.2"
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -5348,13 +2323,10 @@ packages:
         optional: true
 
   ws@8.20.0:
-    resolution:
-      {
-        integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==,
-      }
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     peerDependencies:
       bufferutil: ^4.0.1
-      utf-8-validate: ">=5.0.2"
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -5362,564 +2334,341 @@ packages:
         optional: true
 
   xmlbuilder2@4.0.3:
-    resolution:
-      {
-        integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==,
-      }
+    resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
 
   yallist@3.1.1:
-    resolution:
-      {
-        integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
-      }
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
   youch-core@0.3.3:
-    resolution:
-      {
-        integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==,
-      }
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
 
   youch@4.1.0-beta.10:
-    resolution:
-      {
-        integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==,
-      }
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zod@3.25.76:
-    resolution:
-      {
-        integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
-      }
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zwitch@2.0.4:
-    resolution:
-      {
-        integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
-      }
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-  "@babel/code-frame@7.27.1":
+
+  '@babel/code-frame@7.27.1':
     dependencies:
-      "@babel/helper-validator-identifier": 7.28.5
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  "@babel/code-frame@7.29.0":
+  '@babel/code-frame@7.29.0':
     dependencies:
-      "@babel/helper-validator-identifier": 7.28.5
+      '@babel/helper-validator-identifier': 7.28.5
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  "@babel/compat-data@7.29.0": {}
+  '@babel/compat-data@7.29.0': {}
 
-  "@babel/core@7.29.0":
+  '@babel/core@7.29.0':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/helper-compilation-targets": 7.28.6
-      "@babel/helper-module-transforms": 7.28.6
-      "@babel/helpers": 7.29.2
-      "@babel/parser": 7.29.2
-      "@babel/template": 7.28.6
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
-      "@jridgewell/remapping": 2.3.5
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
 
-  "@babel/generator@7.29.1":
+  '@babel/generator@7.29.1':
     dependencies:
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
-      "@jridgewell/gen-mapping": 0.3.13
-      "@jridgewell/trace-mapping": 0.3.31
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  "@babel/helper-compilation-targets@7.28.6":
+  '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      "@babel/compat-data": 7.29.0
-      "@babel/helper-validator-option": 7.27.1
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  "@babel/helper-globals@7.28.0": {}
+  '@babel/helper-globals@7.28.0': {}
 
-  "@babel/helper-module-imports@7.28.6":
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
 
-  "@babel/helper-module-transforms@7.28.6":
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      "@babel/helper-module-imports": 7.28.6
-      "@babel/helper-validator-identifier": 7.28.5
-      "@babel/traverse": 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
 
-  "@babel/helper-plugin-utils@7.28.6": {}
+  '@babel/helper-plugin-utils@7.28.6': {}
 
-  "@babel/helper-string-parser@7.27.1": {}
+  '@babel/helper-string-parser@7.27.1': {}
 
-  "@babel/helper-validator-identifier@7.28.5": {}
+  '@babel/helper-validator-identifier@7.28.5': {}
 
-  "@babel/helper-validator-option@7.27.1": {}
+  '@babel/helper-validator-option@7.27.1': {}
 
-  "@babel/helpers@7.29.2":
+  '@babel/helpers@7.29.2':
     dependencies:
-      "@babel/template": 7.28.6
-      "@babel/types": 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
-  "@babel/parser@7.29.2":
+  '@babel/parser@7.29.2':
     dependencies:
-      "@babel/types": 7.29.0
+      '@babel/types': 7.29.0
 
-  "@babel/plugin-syntax-jsx@7.28.6":
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      "@babel/helper-plugin-utils": 7.28.6
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
 
-  "@babel/plugin-syntax-typescript@7.28.6":
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      "@babel/helper-plugin-utils": 7.28.6
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
 
-  "@babel/runtime@7.29.2": {}
-
-  "@babel/template@7.28.6":
+  '@babel/template@7.28.6':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
-  "@babel/traverse@7.29.0":
+  '@babel/traverse@7.29.0':
     dependencies:
-      "@babel/code-frame": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/helper-globals": 7.28.0
-      "@babel/parser": 7.29.2
-      "@babel/template": 7.28.6
-      "@babel/types": 7.29.0
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
       debug: 4.4.3
 
-  "@babel/types@7.29.0":
+  '@babel/types@7.29.0':
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
-  "@cloudflare/kv-asset-handler@0.5.0": {}
+  '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  "@cloudflare/unenv-preset@2.16.1": {}
-
-  "@cloudflare/vite-plugin@1.36.3":
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)':
     dependencies:
-      "@cloudflare/unenv-preset": 2.16.1
-      miniflare: 4.20260507.1
       unenv: 2.0.0-rc.24
-      wrangler: 4.90.0
+      workerd: 1.20260511.1
+
+  '@cloudflare/vite-plugin@1.37.0(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))(wrangler@4.91.0)':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)
+      miniflare: 4.20260511.0
+      unenv: 2.0.0-rc.24
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
+      wrangler: 4.91.0
       ws: 8.18.0
 
-  "@cloudflare/workerd-darwin-64@1.20260507.1": {}
+  '@cloudflare/workerd-darwin-arm64@1.20260511.1': {}
 
-  "@cloudflare/workerd-darwin-arm64@1.20260507.1": {}
+  '@cloudflare/workerd-linux-64@1.20260511.1': {}
 
-  "@cloudflare/workerd-linux-64@1.20260507.1": {}
+  '@cloudflare/workerd-linux-arm64@1.20260511.1': {}
 
-  "@cloudflare/workerd-linux-arm64@1.20260507.1": {}
+  '@cloudflare/workerd-windows-64@1.20260511.1': {}
 
-  "@cloudflare/workerd-windows-64@1.20260507.1": {}
+  '@colors/colors@1.5.0': {}
 
-  "@cspotcode/source-map-support@0.8.1":
+  '@cspotcode/source-map-support@0.8.1':
     dependencies:
-      "@jridgewell/trace-mapping": 0.3.9
+      '@jridgewell/trace-mapping': 0.3.9
 
-  "@emnapi/core@1.10.0":
+  '@esbuild/darwin-arm64@0.25.12': {}
+
+  '@esbuild/darwin-arm64@0.27.3': {}
+
+  '@esbuild/linux-arm64@0.25.12': {}
+
+  '@esbuild/linux-arm64@0.27.3': {}
+
+  '@esbuild/linux-x64@0.25.12': {}
+
+  '@esbuild/linux-x64@0.27.3': {}
+
+  '@esbuild/win32-arm64@0.25.12': {}
+
+  '@esbuild/win32-arm64@0.27.3': {}
+
+  '@esbuild/win32-x64@0.25.12': {}
+
+  '@esbuild/win32-x64@0.27.3': {}
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4': {}
+
+  '@img/sharp-libvips-linux-arm64@1.2.4': {}
+
+  '@img/sharp-libvips-linux-x64@1.2.4': {}
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4': {}
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4': {}
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+
+  '@img/sharp-win32-arm64@0.34.5': {}
+
+  '@img/sharp-win32-x64@0.34.5': {}
+
+  '@jest/schemas@29.6.3':
     dependencies:
-      "@emnapi/wasi-threads": 1.2.1
-      tslib: 2.8.1
+      '@sinclair/typebox': 0.27.10
 
-  "@emnapi/runtime@1.10.0":
+  '@jest/types@29.6.3':
     dependencies:
-      tslib: 2.8.1
-
-  "@emnapi/wasi-threads@1.2.1":
-    dependencies:
-      tslib: 2.8.1
-
-  "@esbuild/aix-ppc64@0.25.12": {}
-
-  "@esbuild/aix-ppc64@0.27.3": {}
-
-  "@esbuild/aix-ppc64@0.27.7": {}
-
-  "@esbuild/android-arm64@0.25.12": {}
-
-  "@esbuild/android-arm64@0.27.3": {}
-
-  "@esbuild/android-arm64@0.27.7": {}
-
-  "@esbuild/android-arm@0.25.12": {}
-
-  "@esbuild/android-arm@0.27.3": {}
-
-  "@esbuild/android-arm@0.27.7": {}
-
-  "@esbuild/android-x64@0.25.12": {}
-
-  "@esbuild/android-x64@0.27.3": {}
-
-  "@esbuild/android-x64@0.27.7": {}
-
-  "@esbuild/darwin-arm64@0.25.12": {}
-
-  "@esbuild/darwin-arm64@0.27.3": {}
-
-  "@esbuild/darwin-arm64@0.27.7": {}
-
-  "@esbuild/darwin-x64@0.25.12": {}
-
-  "@esbuild/darwin-x64@0.27.3": {}
-
-  "@esbuild/darwin-x64@0.27.7": {}
-
-  "@esbuild/freebsd-arm64@0.25.12": {}
-
-  "@esbuild/freebsd-arm64@0.27.3": {}
-
-  "@esbuild/freebsd-arm64@0.27.7": {}
-
-  "@esbuild/freebsd-x64@0.25.12": {}
-
-  "@esbuild/freebsd-x64@0.27.3": {}
-
-  "@esbuild/freebsd-x64@0.27.7": {}
-
-  "@esbuild/linux-arm64@0.25.12": {}
-
-  "@esbuild/linux-arm64@0.27.3": {}
-
-  "@esbuild/linux-arm64@0.27.7": {}
-
-  "@esbuild/linux-arm@0.25.12": {}
-
-  "@esbuild/linux-arm@0.27.3": {}
-
-  "@esbuild/linux-arm@0.27.7": {}
-
-  "@esbuild/linux-ia32@0.25.12": {}
-
-  "@esbuild/linux-ia32@0.27.3": {}
-
-  "@esbuild/linux-ia32@0.27.7": {}
-
-  "@esbuild/linux-loong64@0.25.12": {}
-
-  "@esbuild/linux-loong64@0.27.3": {}
-
-  "@esbuild/linux-loong64@0.27.7": {}
-
-  "@esbuild/linux-mips64el@0.25.12": {}
-
-  "@esbuild/linux-mips64el@0.27.3": {}
-
-  "@esbuild/linux-mips64el@0.27.7": {}
-
-  "@esbuild/linux-ppc64@0.25.12": {}
-
-  "@esbuild/linux-ppc64@0.27.3": {}
-
-  "@esbuild/linux-ppc64@0.27.7": {}
-
-  "@esbuild/linux-riscv64@0.25.12": {}
-
-  "@esbuild/linux-riscv64@0.27.3": {}
-
-  "@esbuild/linux-riscv64@0.27.7": {}
-
-  "@esbuild/linux-s390x@0.25.12": {}
-
-  "@esbuild/linux-s390x@0.27.3": {}
-
-  "@esbuild/linux-s390x@0.27.7": {}
-
-  "@esbuild/linux-x64@0.25.12": {}
-
-  "@esbuild/linux-x64@0.27.3": {}
-
-  "@esbuild/linux-x64@0.27.7": {}
-
-  "@esbuild/netbsd-arm64@0.25.12": {}
-
-  "@esbuild/netbsd-arm64@0.27.3": {}
-
-  "@esbuild/netbsd-arm64@0.27.7": {}
-
-  "@esbuild/netbsd-x64@0.25.12": {}
-
-  "@esbuild/netbsd-x64@0.27.3": {}
-
-  "@esbuild/netbsd-x64@0.27.7": {}
-
-  "@esbuild/openbsd-arm64@0.25.12": {}
-
-  "@esbuild/openbsd-arm64@0.27.3": {}
-
-  "@esbuild/openbsd-arm64@0.27.7": {}
-
-  "@esbuild/openbsd-x64@0.25.12": {}
-
-  "@esbuild/openbsd-x64@0.27.3": {}
-
-  "@esbuild/openbsd-x64@0.27.7": {}
-
-  "@esbuild/openharmony-arm64@0.25.12": {}
-
-  "@esbuild/openharmony-arm64@0.27.3": {}
-
-  "@esbuild/openharmony-arm64@0.27.7": {}
-
-  "@esbuild/sunos-x64@0.25.12": {}
-
-  "@esbuild/sunos-x64@0.27.3": {}
-
-  "@esbuild/sunos-x64@0.27.7": {}
-
-  "@esbuild/win32-arm64@0.25.12": {}
-
-  "@esbuild/win32-arm64@0.27.3": {}
-
-  "@esbuild/win32-arm64@0.27.7": {}
-
-  "@esbuild/win32-ia32@0.25.12": {}
-
-  "@esbuild/win32-ia32@0.27.3": {}
-
-  "@esbuild/win32-ia32@0.27.7": {}
-
-  "@esbuild/win32-x64@0.25.12": {}
-
-  "@esbuild/win32-x64@0.27.3": {}
-
-  "@esbuild/win32-x64@0.27.7": {}
-
-  "@img/colour@1.1.0": {}
-
-  "@img/sharp-darwin-arm64@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-darwin-arm64": 1.2.4
-
-  "@img/sharp-darwin-x64@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-darwin-x64": 1.2.4
-
-  "@img/sharp-libvips-darwin-arm64@1.2.4": {}
-
-  "@img/sharp-libvips-darwin-x64@1.2.4": {}
-
-  "@img/sharp-libvips-linux-arm64@1.2.4": {}
-
-  "@img/sharp-libvips-linux-arm@1.2.4": {}
-
-  "@img/sharp-libvips-linux-ppc64@1.2.4": {}
-
-  "@img/sharp-libvips-linux-riscv64@1.2.4": {}
-
-  "@img/sharp-libvips-linux-s390x@1.2.4": {}
-
-  "@img/sharp-libvips-linux-x64@1.2.4": {}
-
-  "@img/sharp-libvips-linuxmusl-arm64@1.2.4": {}
-
-  "@img/sharp-libvips-linuxmusl-x64@1.2.4": {}
-
-  "@img/sharp-linux-arm64@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-arm64": 1.2.4
-
-  "@img/sharp-linux-arm@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-arm": 1.2.4
-
-  "@img/sharp-linux-ppc64@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-ppc64": 1.2.4
-
-  "@img/sharp-linux-riscv64@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-riscv64": 1.2.4
-
-  "@img/sharp-linux-s390x@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-s390x": 1.2.4
-
-  "@img/sharp-linux-x64@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-x64": 1.2.4
-
-  "@img/sharp-linuxmusl-arm64@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-arm64": 1.2.4
-
-  "@img/sharp-linuxmusl-x64@0.34.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-x64": 1.2.4
-
-  "@img/sharp-wasm32@0.34.5":
-    dependencies:
-      "@emnapi/runtime": 1.10.0
-
-  "@img/sharp-win32-arm64@0.34.5": {}
-
-  "@img/sharp-win32-ia32@0.34.5": {}
-
-  "@img/sharp-win32-x64@0.34.5": {}
-
-  "@isaacs/cliui@9.0.0": {}
-
-  "@jest/schemas@29.6.3":
-    dependencies:
-      "@sinclair/typebox": 0.27.10
-
-  "@jest/types@29.6.3":
-    dependencies:
-      "@jest/schemas": 29.6.3
-      "@types/istanbul-lib-coverage": 2.0.6
-      "@types/istanbul-reports": 3.0.4
-      "@types/node": 25.5.2
-      "@types/yargs": 17.0.35
+      '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 25.5.2
+      '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  "@jridgewell/gen-mapping@0.3.13":
+  '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
-      "@jridgewell/trace-mapping": 0.3.31
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
 
-  "@jridgewell/remapping@2.3.5":
+  '@jridgewell/remapping@2.3.5':
     dependencies:
-      "@jridgewell/gen-mapping": 0.3.13
-      "@jridgewell/trace-mapping": 0.3.31
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
-  "@jridgewell/resolve-uri@3.1.2": {}
+  '@jridgewell/resolve-uri@3.1.2': {}
 
-  "@jridgewell/sourcemap-codec@1.5.5": {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  "@jridgewell/trace-mapping@0.3.31":
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
-      "@jridgewell/resolve-uri": 3.1.2
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
-  "@jridgewell/trace-mapping@0.3.9":
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
-      "@jridgewell/resolve-uri": 3.1.2
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
-  "@lingui/babel-plugin-extract-messages@5.9.4": {}
+  '@lingui/babel-plugin-extract-messages@6.0.1': {}
 
-  "@lingui/babel-plugin-lingui-macro@5.9.4":
+  '@lingui/babel-plugin-lingui-macro@6.0.1':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/runtime": 7.29.2
-      "@babel/types": 7.29.0
-      "@lingui/conf": 5.9.4
-      "@lingui/core": 5.9.4
-      "@lingui/message-utils": 5.9.4
+      '@babel/core': 7.29.0
+      '@babel/types': 7.29.0
+      '@lingui/conf': 6.0.1
+      '@lingui/message-utils': 6.0.1
 
-  "@lingui/babel-plugin-lingui-macro@6.0.1":
+  '@lingui/cli@6.0.1':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/types": 7.29.0
-      "@lingui/conf": 6.0.1
-      "@lingui/message-utils": 6.0.1
-
-  "@lingui/cli@5.9.4":
-    dependencies:
-      "@babel/core": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/parser": 7.29.2
-      "@babel/runtime": 7.29.2
-      "@babel/types": 7.29.0
-      "@lingui/babel-plugin-extract-messages": 5.9.4
-      "@lingui/babel-plugin-lingui-macro": 5.9.4
-      "@lingui/conf": 5.9.4
-      "@lingui/core": 5.9.4
-      "@lingui/format-po": 5.9.4
-      "@lingui/message-utils": 5.9.4
-      chokidar: 3.5.1
-      cli-table: 0.3.11
-      commander: 10.0.1
-      convert-source-map: 2.0.0
-      date-fns: 3.6.0
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@lingui/babel-plugin-extract-messages': 6.0.1
+      '@lingui/babel-plugin-lingui-macro': 6.0.1
+      '@lingui/conf': 6.0.1
+      '@lingui/core': 6.0.1
+      '@lingui/format-po': 6.0.1
+      '@lingui/message-utils': 6.0.1
+      chokidar: 5.0.0
+      cli-table3: 0.6.5
+      commander: 14.0.3
       esbuild: 0.25.12
-      glob: 11.1.0
+      jiti: 2.6.1
       micromatch: 4.0.8
       ms: 2.1.3
       normalize-path: 3.0.0
-      ora: 5.4.1
-      picocolors: 1.1.1
-      pofile: 1.1.4
+      ora: 9.4.0
       pseudolocale: 2.2.0
       source-map: 0.7.6
-      threads: 1.7.0
+      tinypool: 2.1.0
 
-  "@lingui/conf@5.9.4":
-    dependencies:
-      "@babel/runtime": 7.29.2
-      cosmiconfig: 8.3.6
-      jest-validate: 29.7.0
-      jiti: 2.6.1
-      picocolors: 1.1.1
-
-  "@lingui/conf@6.0.1":
+  '@lingui/conf@6.0.1':
     dependencies:
       jest-validate: 29.7.0
       jiti: 2.6.1
       lilconfig: 3.1.3
       normalize-path: 3.0.0
 
-  "@lingui/core@5.9.4":
+  '@lingui/core@6.0.1':
     dependencies:
-      "@babel/runtime": 7.29.2
-      "@lingui/message-utils": 5.9.4
+      '@lingui/babel-plugin-lingui-macro': 6.0.1
+      '@lingui/message-utils': 6.0.1
 
-  "@lingui/core@6.0.1":
+  '@lingui/format-po@6.0.1':
     dependencies:
-      "@lingui/babel-plugin-lingui-macro": 6.0.1
-      "@lingui/message-utils": 6.0.1
-
-  "@lingui/format-po@5.9.4":
-    dependencies:
-      "@lingui/conf": 5.9.4
-      "@lingui/message-utils": 5.9.4
-      date-fns: 3.6.0
+      '@lingui/conf': 6.0.1
+      '@lingui/message-utils': 6.0.1
       pofile: 1.1.4
 
-  "@lingui/message-utils@5.9.4":
+  '@lingui/message-utils@6.0.1':
     dependencies:
-      "@messageformat/parser": 5.1.1
+      '@messageformat/date-skeleton': 1.1.0
+      '@messageformat/parser': 5.1.1
       js-sha256: 0.10.1
 
-  "@lingui/message-utils@6.0.1":
+  '@lingui/react@6.0.1(react@19.2.6)':
     dependencies:
-      "@messageformat/date-skeleton": 1.1.0
-      "@messageformat/parser": 5.1.1
-      js-sha256: 0.10.1
+      '@lingui/babel-plugin-lingui-macro': 6.0.1
+      '@lingui/core': 6.0.1
+      react: 19.2.6
+  ? '@lingui/vite-plugin@6.0.1(@babel/core@7.29.0)(@lingui/babel-plugin-lingui-macro@6.0.1)(rolldown@1.0.1)(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))'
 
-  "@lingui/react@6.0.1":
-    dependencies:
-      "@lingui/babel-plugin-lingui-macro": 6.0.1
-      "@lingui/core": 6.0.1
+  : dependencies:
+      '@babel/core': 7.29.0
+      '@lingui/babel-plugin-lingui-macro': 6.0.1
+      '@lingui/cli': 6.0.1
+      '@lingui/conf': 6.0.1
+      rolldown: 1.0.1
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
 
-  "@lingui/vite-plugin@5.9.4":
+  '@mdx-js/mdx@3.1.1(acorn@8.16.0)':
     dependencies:
-      "@lingui/cli": 5.9.4
-      "@lingui/conf": 5.9.4
-
-  "@mdx-js/mdx@3.1.1":
-    dependencies:
-      "@types/estree": 1.0.8
-      "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
-      "@types/mdx": 2.0.13
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdx': 2.0.13
       acorn: 8.16.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
@@ -5929,10 +2678,10 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1
+      recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
-      remark-mdx: 3.1.1
+      remark-mdx: 3.1.1(acorn@8.16.0)
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       source-map: 0.7.6
@@ -5942,262 +2691,179 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
-  "@mdx-js/rollup@3.1.1":
+  '@mdx-js/rollup@3.1.1(rollup@4.60.1)':
     dependencies:
-      "@mdx-js/mdx": 3.1.1
-      "@rollup/pluginutils": 5.3.0
+      '@mdx-js/mdx': 3.1.1(acorn@8.16.0)
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
+      rollup: 4.60.1
       source-map: 0.7.6
       vfile: 6.0.3
 
-  "@messageformat/date-skeleton@1.1.0": {}
+  '@messageformat/date-skeleton@1.1.0': {}
 
-  "@messageformat/parser@5.1.1":
+  '@messageformat/parser@5.1.1':
     dependencies:
       moo: 0.5.3
 
-  "@napi-rs/wasm-runtime@1.1.4":
+  '@oozcitak/dom@2.0.2':
     dependencies:
-      "@tybys/wasm-util": 0.10.1
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/url': 3.0.0
+      '@oozcitak/util': 10.0.0
 
-  "@oozcitak/dom@2.0.2":
+  '@oozcitak/infra@2.0.2':
     dependencies:
-      "@oozcitak/infra": 2.0.2
-      "@oozcitak/url": 3.0.0
-      "@oozcitak/util": 10.0.0
+      '@oozcitak/util': 10.0.0
 
-  "@oozcitak/infra@2.0.2":
+  '@oozcitak/url@3.0.0':
     dependencies:
-      "@oozcitak/util": 10.0.0
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/util': 10.0.0
 
-  "@oozcitak/url@3.0.0":
-    dependencies:
-      "@oozcitak/infra": 2.0.2
-      "@oozcitak/util": 10.0.0
+  '@oozcitak/util@10.0.0': {}
 
-  "@oozcitak/util@10.0.0": {}
+  '@oxc-parser/binding-darwin-arm64@0.120.0': {}
 
-  "@oxc-project/types@0.128.0": {}
+  '@oxc-parser/binding-linux-arm64-gnu@0.120.0': {}
 
-  "@oxfmt/binding-android-arm-eabi@0.48.0": {}
+  '@oxc-parser/binding-linux-arm64-musl@0.120.0': {}
 
-  "@oxfmt/binding-android-arm64@0.48.0": {}
+  '@oxc-parser/binding-linux-x64-gnu@0.120.0': {}
 
-  "@oxfmt/binding-darwin-arm64@0.48.0": {}
+  '@oxc-parser/binding-linux-x64-musl@0.120.0': {}
 
-  "@oxfmt/binding-darwin-x64@0.48.0": {}
+  '@oxc-parser/binding-win32-arm64-msvc@0.120.0': {}
 
-  "@oxfmt/binding-freebsd-x64@0.48.0": {}
+  '@oxc-parser/binding-win32-x64-msvc@0.120.0': {}
 
-  "@oxfmt/binding-linux-arm-gnueabihf@0.48.0": {}
+  '@oxc-project/types@0.120.0': {}
 
-  "@oxfmt/binding-linux-arm-musleabihf@0.48.0": {}
+  '@oxc-project/types@0.130.0': {}
 
-  "@oxfmt/binding-linux-arm64-gnu@0.48.0": {}
+  '@oxfmt/binding-darwin-arm64@0.49.0': {}
 
-  "@oxfmt/binding-linux-arm64-musl@0.48.0": {}
+  '@oxfmt/binding-linux-arm64-gnu@0.49.0': {}
 
-  "@oxfmt/binding-linux-ppc64-gnu@0.48.0": {}
+  '@oxfmt/binding-linux-arm64-musl@0.49.0': {}
 
-  "@oxfmt/binding-linux-riscv64-gnu@0.48.0": {}
+  '@oxfmt/binding-linux-x64-gnu@0.49.0': {}
 
-  "@oxfmt/binding-linux-riscv64-musl@0.48.0": {}
+  '@oxfmt/binding-linux-x64-musl@0.49.0': {}
 
-  "@oxfmt/binding-linux-s390x-gnu@0.48.0": {}
+  '@oxfmt/binding-win32-arm64-msvc@0.49.0': {}
 
-  "@oxfmt/binding-linux-x64-gnu@0.48.0": {}
+  '@oxfmt/binding-win32-x64-msvc@0.49.0': {}
 
-  "@oxfmt/binding-linux-x64-musl@0.48.0": {}
+  '@oxlint/binding-darwin-arm64@1.64.0': {}
 
-  "@oxfmt/binding-openharmony-arm64@0.48.0": {}
+  '@oxlint/binding-linux-arm64-gnu@1.64.0': {}
 
-  "@oxfmt/binding-win32-arm64-msvc@0.48.0": {}
+  '@oxlint/binding-linux-arm64-musl@1.64.0': {}
 
-  "@oxfmt/binding-win32-ia32-msvc@0.48.0": {}
+  '@oxlint/binding-linux-x64-gnu@1.64.0': {}
 
-  "@oxfmt/binding-win32-x64-msvc@0.48.0": {}
+  '@oxlint/binding-linux-x64-musl@1.64.0': {}
 
-  "@oxlint/binding-android-arm-eabi@1.63.0": {}
+  '@oxlint/binding-win32-arm64-msvc@1.64.0': {}
 
-  "@oxlint/binding-android-arm64@1.63.0": {}
+  '@oxlint/binding-win32-x64-msvc@1.64.0': {}
 
-  "@oxlint/binding-darwin-arm64@1.63.0": {}
-
-  "@oxlint/binding-darwin-x64@1.63.0": {}
-
-  "@oxlint/binding-freebsd-x64@1.63.0": {}
-
-  "@oxlint/binding-linux-arm-gnueabihf@1.63.0": {}
-
-  "@oxlint/binding-linux-arm-musleabihf@1.63.0": {}
-
-  "@oxlint/binding-linux-arm64-gnu@1.63.0": {}
-
-  "@oxlint/binding-linux-arm64-musl@1.63.0": {}
-
-  "@oxlint/binding-linux-ppc64-gnu@1.63.0": {}
-
-  "@oxlint/binding-linux-riscv64-gnu@1.63.0": {}
-
-  "@oxlint/binding-linux-riscv64-musl@1.63.0": {}
-
-  "@oxlint/binding-linux-s390x-gnu@1.63.0": {}
-
-  "@oxlint/binding-linux-x64-gnu@1.63.0": {}
-
-  "@oxlint/binding-linux-x64-musl@1.63.0": {}
-
-  "@oxlint/binding-openharmony-arm64@1.63.0": {}
-
-  "@oxlint/binding-win32-arm64-msvc@1.63.0": {}
-
-  "@oxlint/binding-win32-ia32-msvc@1.63.0": {}
-
-  "@oxlint/binding-win32-x64-msvc@1.63.0": {}
-
-  "@poppinss/colors@4.1.6":
+  '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
 
-  "@poppinss/dumper@0.6.5":
+  '@poppinss/dumper@0.6.5':
     dependencies:
-      "@poppinss/colors": 4.1.6
-      "@sindresorhus/is": 7.2.0
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
       supports-color: 10.2.2
 
-  "@poppinss/exception@1.2.3": {}
+  '@poppinss/exception@1.2.3': {}
 
-  "@rolldown/binding-android-arm64@1.0.0-rc.18": {}
+  '@rolldown/binding-darwin-arm64@1.0.1': {}
 
-  "@rolldown/binding-darwin-arm64@1.0.0-rc.18": {}
+  '@rolldown/binding-linux-arm64-gnu@1.0.1': {}
 
-  "@rolldown/binding-darwin-x64@1.0.0-rc.18": {}
+  '@rolldown/binding-linux-arm64-musl@1.0.1': {}
 
-  "@rolldown/binding-freebsd-x64@1.0.0-rc.18": {}
+  '@rolldown/binding-linux-x64-gnu@1.0.1': {}
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.18": {}
+  '@rolldown/binding-linux-x64-musl@1.0.1': {}
 
-  "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.18": {}
+  '@rolldown/binding-win32-arm64-msvc@1.0.1': {}
 
-  "@rolldown/binding-linux-arm64-musl@1.0.0-rc.18": {}
+  '@rolldown/binding-win32-x64-msvc@1.0.1': {}
 
-  "@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.18": {}
+  '@rolldown/pluginutils@1.0.0-beta.40': {}
 
-  "@rolldown/binding-linux-s390x-gnu@1.0.0-rc.18": {}
+  '@rolldown/pluginutils@1.0.1': {}
 
-  "@rolldown/binding-linux-x64-gnu@1.0.0-rc.18": {}
-
-  "@rolldown/binding-linux-x64-musl@1.0.0-rc.18": {}
-
-  "@rolldown/binding-openharmony-arm64@1.0.0-rc.18": {}
-
-  "@rolldown/binding-wasm32-wasi@1.0.0-rc.18":
+  '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
     dependencies:
-      "@emnapi/core": 1.10.0
-      "@emnapi/runtime": 1.10.0
-      "@napi-rs/wasm-runtime": 1.1.4
-
-  "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.18": {}
-
-  "@rolldown/binding-win32-x64-msvc@1.0.0-rc.18": {}
-
-  "@rolldown/pluginutils@1.0.0-beta.40": {}
-
-  "@rolldown/pluginutils@1.0.0-rc.18": {}
-
-  "@rolldown/pluginutils@1.0.0-rc.7": {}
-
-  "@rollup/pluginutils@5.3.0":
-    dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       estree-walker: 2.0.2
       picomatch: 4.0.4
+      rollup: 4.60.1
 
-  "@rollup/rollup-android-arm-eabi@4.60.1": {}
+  '@rollup/rollup-darwin-arm64@4.60.1': {}
 
-  "@rollup/rollup-android-arm64@4.60.1": {}
+  '@rollup/rollup-linux-arm64-gnu@4.60.1': {}
 
-  "@rollup/rollup-darwin-arm64@4.60.1": {}
+  '@rollup/rollup-linux-arm64-musl@4.60.1': {}
 
-  "@rollup/rollup-darwin-x64@4.60.1": {}
+  '@rollup/rollup-linux-x64-gnu@4.60.1': {}
 
-  "@rollup/rollup-freebsd-arm64@4.60.1": {}
+  '@rollup/rollup-linux-x64-musl@4.60.1': {}
 
-  "@rollup/rollup-freebsd-x64@4.60.1": {}
+  '@rollup/rollup-win32-arm64-msvc@4.60.1': {}
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.60.1": {}
+  '@rollup/rollup-win32-x64-gnu@4.60.1': {}
 
-  "@rollup/rollup-linux-arm-musleabihf@4.60.1": {}
+  '@rollup/rollup-win32-x64-msvc@4.60.1': {}
 
-  "@rollup/rollup-linux-arm64-gnu@4.60.1": {}
+  '@sinclair/typebox@0.27.10': {}
 
-  "@rollup/rollup-linux-arm64-musl@4.60.1": {}
+  '@sindresorhus/is@7.2.0': {}
 
-  "@rollup/rollup-linux-loong64-gnu@4.60.1": {}
-
-  "@rollup/rollup-linux-loong64-musl@4.60.1": {}
-
-  "@rollup/rollup-linux-ppc64-gnu@4.60.1": {}
-
-  "@rollup/rollup-linux-ppc64-musl@4.60.1": {}
-
-  "@rollup/rollup-linux-riscv64-gnu@4.60.1": {}
-
-  "@rollup/rollup-linux-riscv64-musl@4.60.1": {}
-
-  "@rollup/rollup-linux-s390x-gnu@4.60.1": {}
-
-  "@rollup/rollup-linux-x64-gnu@4.60.1": {}
-
-  "@rollup/rollup-linux-x64-musl@4.60.1": {}
-
-  "@rollup/rollup-openbsd-x64@4.60.1": {}
-
-  "@rollup/rollup-openharmony-arm64@4.60.1": {}
-
-  "@rollup/rollup-win32-arm64-msvc@4.60.1": {}
-
-  "@rollup/rollup-win32-ia32-msvc@4.60.1": {}
-
-  "@rollup/rollup-win32-x64-gnu@4.60.1": {}
-
-  "@rollup/rollup-win32-x64-msvc@4.60.1": {}
-
-  "@sinclair/typebox@0.27.10": {}
-
-  "@sindresorhus/is@7.2.0": {}
-
-  "@solid-primitives/event-listener@2.4.5":
+  '@solid-primitives/event-listener@2.4.5(solid-js@1.9.12)':
     dependencies:
-      "@solid-primitives/utils": 6.4.0
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12(seroval@1.5.2)
 
-  "@solid-primitives/keyboard@1.3.5":
+  '@solid-primitives/keyboard@1.3.5(solid-js@1.9.12)':
     dependencies:
-      "@solid-primitives/event-listener": 2.4.5
-      "@solid-primitives/rootless": 1.5.3
-      "@solid-primitives/utils": 6.4.0
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12(seroval@1.5.2)
 
-  "@solid-primitives/resize-observer@2.1.5":
+  '@solid-primitives/resize-observer@2.1.5(solid-js@1.9.12)':
     dependencies:
-      "@solid-primitives/event-listener": 2.4.5
-      "@solid-primitives/rootless": 1.5.3
-      "@solid-primitives/static-store": 0.1.3
-      "@solid-primitives/utils": 6.4.0
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
+      '@solid-primitives/rootless': 1.5.3(solid-js@1.9.12)
+      '@solid-primitives/static-store': 0.1.3(solid-js@1.9.12)
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12(seroval@1.5.2)
 
-  "@solid-primitives/rootless@1.5.3":
+  '@solid-primitives/rootless@1.5.3(solid-js@1.9.12)':
     dependencies:
-      "@solid-primitives/utils": 6.4.0
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12(seroval@1.5.2)
 
-  "@solid-primitives/static-store@0.1.3":
+  '@solid-primitives/static-store@0.1.3(solid-js@1.9.12)':
     dependencies:
-      "@solid-primitives/utils": 6.4.0
+      '@solid-primitives/utils': 6.4.0(solid-js@1.9.12)
+      solid-js: 1.9.12(seroval@1.5.2)
 
-  "@solid-primitives/utils@6.4.0": {}
-
-  "@speed-highlight/core@1.2.15": {}
-
-  "@tailwindcss/node@4.3.0":
+  '@solid-primitives/utils@6.4.0(solid-js@1.9.12)':
     dependencies:
-      "@jridgewell/remapping": 2.3.5
+      solid-js: 1.9.12(seroval@1.5.2)
+
+  '@speed-highlight/core@1.2.15': {}
+
+  '@tailwindcss/node@4.3.0':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
       enhanced-resolve: 5.21.2
       jiti: 2.6.1
       lightningcss: 1.32.0
@@ -6205,393 +2871,364 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.3.0
 
-  "@tailwindcss/oxide-android-arm64@4.3.0": {}
+  '@tailwindcss/oxide-darwin-arm64@4.3.0': {}
 
-  "@tailwindcss/oxide-darwin-arm64@4.3.0": {}
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.0': {}
 
-  "@tailwindcss/oxide-darwin-x64@4.3.0": {}
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.0': {}
 
-  "@tailwindcss/oxide-freebsd-x64@4.3.0": {}
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.0': {}
 
-  "@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0": {}
+  '@tailwindcss/oxide-linux-x64-musl@4.3.0': {}
 
-  "@tailwindcss/oxide-linux-arm64-gnu@4.3.0": {}
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.0': {}
 
-  "@tailwindcss/oxide-linux-arm64-musl@4.3.0": {}
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.0': {}
 
-  "@tailwindcss/oxide-linux-x64-gnu@4.3.0": {}
-
-  "@tailwindcss/oxide-linux-x64-musl@4.3.0": {}
-
-  "@tailwindcss/oxide-wasm32-wasi@4.3.0":
-    dependencies:
-      "@emnapi/core": 1.10.0
-      "@emnapi/runtime": 1.10.0
-      "@emnapi/wasi-threads": 1.2.1
-      "@napi-rs/wasm-runtime": 1.1.4
-      "@tybys/wasm-util": 0.10.1
-      tslib: 2.8.1
-
-  "@tailwindcss/oxide-win32-arm64-msvc@4.3.0": {}
-
-  "@tailwindcss/oxide-win32-x64-msvc@4.3.0": {}
-
-  "@tailwindcss/oxide@4.3.0":
+  '@tailwindcss/oxide@4.3.0':
     optionalDependencies:
-      "@tailwindcss/oxide-android-arm64": 4.3.0
-      "@tailwindcss/oxide-darwin-arm64": 4.3.0
-      "@tailwindcss/oxide-darwin-x64": 4.3.0
-      "@tailwindcss/oxide-freebsd-x64": 4.3.0
-      "@tailwindcss/oxide-linux-arm-gnueabihf": 4.3.0
-      "@tailwindcss/oxide-linux-arm64-gnu": 4.3.0
-      "@tailwindcss/oxide-linux-arm64-musl": 4.3.0
-      "@tailwindcss/oxide-linux-x64-gnu": 4.3.0
-      "@tailwindcss/oxide-linux-x64-musl": 4.3.0
-      "@tailwindcss/oxide-wasm32-wasi": 4.3.0
-      "@tailwindcss/oxide-win32-arm64-msvc": 4.3.0
-      "@tailwindcss/oxide-win32-x64-msvc": 4.3.0
+      '@tailwindcss/oxide-darwin-arm64': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.0
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.0
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.0
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  "@tailwindcss/typography@0.5.19":
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
     dependencies:
       postcss-selector-parser: 6.0.10
-
-  "@tailwindcss/vite@4.3.0":
-    dependencies:
-      "@tailwindcss/node": 4.3.0
-      "@tailwindcss/oxide": 4.3.0
       tailwindcss: 4.3.0
 
-  "@tanstack/devtools-client@0.0.6":
+  '@tailwindcss/vite@4.3.0(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))':
     dependencies:
-      "@tanstack/devtools-event-client": 0.4.3
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      tailwindcss: 4.3.0
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
 
-  "@tanstack/devtools-event-bus@0.4.1":
+  '@tanstack/devtools-client@0.0.6':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.3
+
+  '@tanstack/devtools-event-bus@0.4.1':
     dependencies:
       ws: 8.20.0
 
-  "@tanstack/devtools-event-client@0.4.3": {}
+  '@tanstack/devtools-event-client@0.4.3': {}
 
-  "@tanstack/devtools-ui@0.5.1":
+  '@tanstack/devtools-ui@0.5.2(solid-js@1.9.12)':
     dependencies:
       clsx: 2.1.1
       dayjs: 1.11.20
-      goober: 2.1.18
-      solid-js: 1.9.12
+      goober: 2.1.18(csstype@3.2.3)
+      solid-js: 1.9.12(seroval@1.5.2)
 
-  "@tanstack/devtools-vite@0.6.0":
+  '@tanstack/devtools-vite@0.7.0(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/parser": 7.29.2
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
-      "@tanstack/devtools-client": 0.0.6
-      "@tanstack/devtools-event-bus": 0.4.1
+      '@tanstack/devtools-client': 0.0.6
+      '@tanstack/devtools-event-bus': 0.4.1
       chalk: 5.6.2
       launch-editor: 2.13.2
+      magic-string: 0.30.21
+      oxc-parser: 0.120.0
       picomatch: 4.0.4
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
 
-  "@tanstack/devtools@0.11.2":
+  '@tanstack/devtools@0.12.2(solid-js@1.9.12)':
     dependencies:
-      "@solid-primitives/event-listener": 2.4.5
-      "@solid-primitives/keyboard": 1.3.5
-      "@solid-primitives/resize-observer": 2.1.5
-      "@tanstack/devtools-client": 0.0.6
-      "@tanstack/devtools-event-bus": 0.4.1
-      "@tanstack/devtools-ui": 0.5.1
+      '@solid-primitives/event-listener': 2.4.5(solid-js@1.9.12)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@1.9.12)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@1.9.12)
+      '@tanstack/devtools-client': 0.0.6
+      '@tanstack/devtools-event-bus': 0.4.1
+      '@tanstack/devtools-ui': 0.5.2(solid-js@1.9.12)
       clsx: 2.1.1
-      goober: 2.1.18
-      solid-js: 1.9.12
+      goober: 2.1.18(csstype@3.2.3)
+      solid-js: 1.9.12(seroval@1.5.2)
 
-  "@tanstack/history@1.161.6": {}
+  '@tanstack/history@1.161.6': {}
 
-  "@tanstack/query-core@5.100.8": {}
+  '@tanstack/query-core@5.100.8': {}
+  ? '@tanstack/react-devtools@0.10.5(@types/react@19.2.14)(@types/react-dom@19.2.3(@types/react@19.2.14))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))'
 
-  "@tanstack/react-devtools@0.10.2":
+  : dependencies:
+      '@tanstack/devtools': 0.12.2(solid-js@1.9.12)
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/react-query@5.100.8(react@19.2.6)':
     dependencies:
-      "@tanstack/devtools": 0.11.2
+      '@tanstack/query-core': 5.100.8
+      react: 19.2.6
+  ? '@tanstack/react-router-devtools@1.166.13(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(@tanstack/router-core@1.169.2)(react@19.2.6)(react-dom@19.2.6(react@19.2.6))'
 
-  "@tanstack/react-query@5.100.8":
-    dependencies:
-      "@tanstack/query-core": 5.100.8
+  : dependencies:
+      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/router-devtools-core': 1.167.3(@tanstack/router-core@1.169.2)(csstype@3.2.3)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+  ? '@tanstack/react-router-ssr-query@1.166.12(@tanstack/query-core@5.100.8)(@tanstack/react-query@5.100.8(react@19.2.6))(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(react@19.2.6)(react-dom@19.2.6(react@19.2.6))'
 
-  "@tanstack/react-router-devtools@1.166.13":
-    dependencies:
-      "@tanstack/router-devtools-core": 1.167.3
+  : dependencies:
+      '@tanstack/query-core': 5.100.8
+      '@tanstack/react-query': 5.100.8(react@19.2.6)
+      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/router-ssr-query-core': 1.168.0(@tanstack/query-core@5.100.8)(@tanstack/router-core@1.169.2)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  "@tanstack/react-router-ssr-query@1.166.12":
+  '@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
     dependencies:
-      "@tanstack/router-ssr-query-core": 1.168.0
-
-  "@tanstack/react-router@1.169.1":
-    dependencies:
-      "@tanstack/history": 1.161.6
-      "@tanstack/react-store": 0.9.3
-      "@tanstack/router-core": 1.169.1
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-store': 0.9.3(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
       isbot: 5.1.37
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  "@tanstack/react-start-client@1.166.47":
+  '@tanstack/react-start-client@1.166.48(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
     dependencies:
-      "@tanstack/react-router": 1.169.1
-      "@tanstack/router-core": 1.169.1
-      "@tanstack/start-client-core": 1.168.1
+      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/start-client-core': 1.168.2(seroval@1.5.4)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  "@tanstack/react-start-rsc@0.0.38":
+  '@tanstack/react-start-rsc@0.0.44(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
     dependencies:
-      "@tanstack/react-router": 1.169.1
-      "@tanstack/react-start-server": 1.166.48
-      "@tanstack/router-core": 1.169.1
-      "@tanstack/router-utils": 1.161.7
-      "@tanstack/start-client-core": 1.168.1
-      "@tanstack/start-fn-stubs": 1.161.6
-      "@tanstack/start-plugin-core": 1.169.14
-      "@tanstack/start-server-core": 1.167.26
-      "@tanstack/start-storage-context": 1.166.34
+      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-start-server': 1.166.52(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/router-utils': 1.161.8(picomatch@4.0.4)
+      '@tanstack/start-client-core': 1.168.2(seroval@1.5.4)
+      '@tanstack/start-fn-stubs': 1.161.6
+      '@tanstack/start-plugin-core': 1.169.20(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
+      '@tanstack/start-server-core': 1.167.30(seroval@1.5.4)
+      '@tanstack/start-storage-context': 1.166.35(seroval@1.5.4)
       pathe: 2.0.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  "@tanstack/react-start-server@1.166.48":
+  '@tanstack/react-start-server@1.166.52(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
     dependencies:
-      "@tanstack/history": 1.161.6
-      "@tanstack/react-router": 1.169.1
-      "@tanstack/router-core": 1.169.1
-      "@tanstack/start-client-core": 1.168.1
-      "@tanstack/start-server-core": 1.167.26
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/start-client-core': 1.168.2(seroval@1.5.4)
+      '@tanstack/start-server-core': 1.167.30(seroval@1.5.4)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+  ? '@tanstack/react-start@1.167.65(react@19.2.6)(react-dom@19.2.6(react@19.2.6))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))'
 
-  "@tanstack/react-start@1.167.59":
-    dependencies:
-      "@tanstack/react-router": 1.169.1
-      "@tanstack/react-start-client": 1.166.47
-      "@tanstack/react-start-rsc": 0.0.38
-      "@tanstack/react-start-server": 1.166.48
-      "@tanstack/router-utils": 1.161.7
-      "@tanstack/start-client-core": 1.168.1
-      "@tanstack/start-plugin-core": 1.169.14
-      "@tanstack/start-server-core": 1.167.26
+  : dependencies:
+      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-start-client': 1.166.48(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-start-rsc': 0.0.44(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/react-start-server': 1.166.52(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/router-utils': 1.161.8(picomatch@4.0.4)
+      '@tanstack/start-client-core': 1.168.2(seroval@1.5.4)
+      '@tanstack/start-plugin-core': 1.169.20(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
+      '@tanstack/start-server-core': 1.167.30(seroval@1.5.4)
       pathe: 2.0.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
 
-  "@tanstack/react-store@0.9.3":
+  '@tanstack/react-store@0.9.3(react@19.2.6)(react-dom@19.2.6(react@19.2.6))':
     dependencies:
-      "@tanstack/store": 0.9.3
-      use-sync-external-store: 1.6.0
+      '@tanstack/store': 0.9.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
 
-  "@tanstack/router-core@1.168.9":
+  '@tanstack/router-core@1.169.2(seroval@1.5.4)':
     dependencies:
-      "@tanstack/history": 1.161.6
-      cookie-es: 2.0.1
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2
-
-  "@tanstack/router-core@1.169.1":
-    dependencies:
-      "@tanstack/history": 1.161.6
+      '@tanstack/history': 1.161.6
       cookie-es: 3.1.1
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  "@tanstack/router-devtools-core@1.167.3":
+  '@tanstack/router-devtools-core@1.167.3(@tanstack/router-core@1.169.2)(csstype@3.2.3)':
     dependencies:
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
       clsx: 2.1.1
-      goober: 2.1.18
+      csstype: 3.2.3
+      goober: 2.1.18(csstype@3.2.3)
 
-  "@tanstack/router-generator@1.166.24":
+  '@tanstack/router-generator@1.166.42(picomatch@4.0.4)(seroval@1.5.4)':
     dependencies:
-      "@tanstack/router-core": 1.168.9
-      "@tanstack/router-utils": 1.161.6
-      "@tanstack/virtual-file-routes": 1.161.7
-      prettier: 3.8.1
-      recast: 0.23.11
-      source-map: 0.7.6
-      tsx: 4.21.0
-      zod: 3.25.76
-
-  "@tanstack/router-generator@1.166.39":
-    dependencies:
-      "@babel/types": 7.29.0
-      "@tanstack/router-core": 1.169.1
-      "@tanstack/router-utils": 1.161.7
-      "@tanstack/virtual-file-routes": 1.161.7
-      jiti: 2.6.1
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/router-utils': 1.161.8(picomatch@4.0.4)
+      '@tanstack/virtual-file-routes': 1.161.7
+      jiti: 2.7.0
       magic-string: 0.30.21
       prettier: 3.8.1
       zod: 3.25.76
+  ? '@tanstack/router-plugin@1.167.35(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))'
 
-  "@tanstack/router-plugin@1.167.12":
-    dependencies:
-      "@babel/core": 7.29.0
-      "@babel/plugin-syntax-jsx": 7.28.6
-      "@babel/plugin-syntax-typescript": 7.28.6
-      "@babel/template": 7.28.6
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
-      "@tanstack/router-core": 1.168.9
-      "@tanstack/router-generator": 1.166.24
-      "@tanstack/router-utils": 1.161.6
-      "@tanstack/virtual-file-routes": 1.161.7
-      chokidar: 3.6.0
-      unplugin: 2.3.11
-      zod: 3.25.76
-
-  "@tanstack/router-plugin@1.167.32":
-    dependencies:
-      "@babel/core": 7.29.0
-      "@babel/plugin-syntax-jsx": 7.28.6
-      "@babel/plugin-syntax-typescript": 7.28.6
-      "@babel/template": 7.28.6
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
-      "@tanstack/router-core": 1.169.1
-      "@tanstack/router-generator": 1.166.39
-      "@tanstack/router-utils": 1.161.7
-      "@tanstack/virtual-file-routes": 1.161.7
+  : dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@tanstack/react-router': 1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6))
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/router-generator': 1.166.42(picomatch@4.0.4)(seroval@1.5.4)
+      '@tanstack/router-utils': 1.161.8(picomatch@4.0.4)
+      '@tanstack/virtual-file-routes': 1.161.7
       chokidar: 3.6.0
       unplugin: 3.0.0
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
       zod: 3.25.76
 
-  "@tanstack/router-ssr-query-core@1.168.0": {}
-
-  "@tanstack/router-utils@1.161.6":
+  '@tanstack/router-ssr-query-core@1.168.0(@tanstack/query-core@5.100.8)(@tanstack/router-core@1.169.2)':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
+      '@tanstack/query-core': 5.100.8
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+
+  '@tanstack/router-utils@1.161.8(picomatch@4.0.4)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       ansis: 4.2.0
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
       pathe: 2.0.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16(picomatch@4.0.4)
 
-  "@tanstack/router-utils@1.161.7":
+  '@tanstack/start-client-core@1.168.2(seroval@1.5.4)':
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/generator": 7.29.1
-      "@babel/parser": 7.29.2
-      "@babel/types": 7.29.0
-      ansis: 4.2.0
-      babel-dead-code-elimination: 1.0.12
-      diff: 8.0.4
-      pathe: 2.0.3
-      tinyglobby: 0.2.15
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/start-fn-stubs': 1.161.6
+      '@tanstack/start-storage-context': 1.166.35(seroval@1.5.4)
+      seroval: 1.5.4
 
-  "@tanstack/start-client-core@1.168.1":
+  '@tanstack/start-fn-stubs@1.161.6': {}
+
+  '@tanstack/start-plugin-core@1.169.20(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))':
     dependencies:
-      "@tanstack/router-core": 1.169.1
-      "@tanstack/start-fn-stubs": 1.161.6
-      "@tanstack/start-storage-context": 1.166.34
-      seroval: 1.5.2
-
-  "@tanstack/start-fn-stubs@1.161.6": {}
-
-  "@tanstack/start-plugin-core@1.169.14":
-    dependencies:
-      "@babel/code-frame": 7.27.1
-      "@babel/core": 7.29.0
-      "@babel/types": 7.29.0
-      "@rolldown/pluginutils": 1.0.0-beta.40
-      "@tanstack/router-core": 1.169.1
-      "@tanstack/router-generator": 1.166.39
-      "@tanstack/router-plugin": 1.167.32
-      "@tanstack/router-utils": 1.161.7
-      "@tanstack/start-client-core": 1.168.1
-      "@tanstack/start-server-core": 1.167.26
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.0
+      '@babel/types': 7.29.0
+      '@rolldown/pluginutils': 1.0.0-beta.40
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/router-generator': 1.166.42(picomatch@4.0.4)(seroval@1.5.4)
+      '@tanstack/router-plugin': 1.167.35(@tanstack/react-router@1.169.2(react@19.2.6)(react-dom@19.2.6(react@19.2.6)))(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
+      '@tanstack/router-utils': 1.161.8(picomatch@4.0.4)
+      '@tanstack/start-client-core': 1.168.2(seroval@1.5.4)
+      '@tanstack/start-server-core': 1.167.30(seroval@1.5.4)
       cheerio: 1.2.0
       exsolve: 1.0.8
       lightningcss: 1.32.0
       pathe: 2.0.3
       picomatch: 4.0.4
-      seroval: 1.5.2
+      seroval: 1.5.4
       source-map: 0.7.6
       srvx: 0.11.15
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16(picomatch@4.0.4)
       ufo: 1.6.3
-      vitefu: 1.1.3
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
+      vitefu: 1.1.3(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))
       xmlbuilder2: 4.0.3
       zod: 3.25.76
 
-  "@tanstack/start-server-core@1.167.26":
+  '@tanstack/start-server-core@1.167.30(seroval@1.5.4)':
     dependencies:
-      "@tanstack/history": 1.161.6
-      "@tanstack/router-core": 1.169.1
-      "@tanstack/start-client-core": 1.168.1
-      "@tanstack/start-storage-context": 1.166.34
+      '@tanstack/history': 1.161.6
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
+      '@tanstack/start-client-core': 1.168.2(seroval@1.5.4)
+      '@tanstack/start-storage-context': 1.166.35(seroval@1.5.4)
+      fetchdts: 0.1.7
       h3-v2: 2.0.1-rc.20
-      seroval: 1.5.2
+      seroval: 1.5.4
 
-  "@tanstack/start-storage-context@1.166.34":
+  '@tanstack/start-storage-context@1.166.35(seroval@1.5.4)':
     dependencies:
-      "@tanstack/router-core": 1.169.1
+      '@tanstack/router-core': 1.169.2(seroval@1.5.4)
 
-  "@tanstack/store@0.9.3": {}
+  '@tanstack/store@0.9.3': {}
 
-  "@tanstack/virtual-file-routes@1.161.7": {}
+  '@tanstack/virtual-file-routes@1.161.7': {}
 
-  "@tybys/wasm-util@0.10.1":
+  '@types/debug@4.1.13':
     dependencies:
-      tslib: 2.8.1
+      '@types/ms': 2.1.0
 
-  "@types/debug@4.1.13":
+  '@types/estree-jsx@1.0.5':
     dependencies:
-      "@types/ms": 2.1.0
+      '@types/estree': 1.0.8
 
-  "@types/estree-jsx@1.0.5":
+  '@types/estree@1.0.8': {}
+
+  '@types/hast@3.0.4':
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/unist': 3.0.3
 
-  "@types/estree@1.0.8": {}
+  '@types/istanbul-lib-coverage@2.0.6': {}
 
-  "@types/hast@3.0.4":
+  '@types/istanbul-lib-report@3.0.3':
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/istanbul-lib-coverage': 2.0.6
 
-  "@types/istanbul-lib-coverage@2.0.6": {}
-
-  "@types/istanbul-lib-report@3.0.3":
+  '@types/istanbul-reports@3.0.4':
     dependencies:
-      "@types/istanbul-lib-coverage": 2.0.6
+      '@types/istanbul-lib-report': 3.0.3
 
-  "@types/istanbul-reports@3.0.4":
+  '@types/mdast@4.0.4':
     dependencies:
-      "@types/istanbul-lib-report": 3.0.3
+      '@types/unist': 3.0.3
 
-  "@types/mdast@4.0.4":
-    dependencies:
-      "@types/unist": 3.0.3
+  '@types/mdx@2.0.13': {}
 
-  "@types/mdx@2.0.13": {}
+  '@types/ms@2.1.0': {}
 
-  "@types/ms@2.1.0": {}
-
-  "@types/node@25.5.2":
+  '@types/node@25.5.2':
     dependencies:
       undici-types: 7.18.2
 
-  "@types/react-dom@19.2.3": {}
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
 
-  "@types/react@19.2.14":
+  '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
 
-  "@types/unist@2.0.11": {}
+  '@types/unist@2.0.11': {}
 
-  "@types/unist@3.0.3": {}
+  '@types/unist@3.0.3': {}
 
-  "@types/yargs-parser@21.0.3": {}
+  '@types/yargs-parser@21.0.3': {}
 
-  "@types/yargs@17.0.35":
+  '@types/yargs@17.0.35':
     dependencies:
-      "@types/yargs-parser": 21.0.3
+      '@types/yargs-parser': 21.0.3
 
-  "@ungap/structured-clone@1.3.0": {}
+  '@ungap/structured-clone@1.3.0': {}
 
-  "@vitejs/plugin-react@6.0.1":
+  '@vitejs/plugin-react@6.0.2(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0))':
     dependencies:
-      "@rolldown/pluginutils": 1.0.0-rc.7
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
 
-  acorn-jsx@5.3.2: {}
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
 
   acorn@8.16.0: {}
 
   ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -6608,42 +3245,24 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  ast-types@0.16.1:
-    dependencies:
-      tslib: 2.8.1
-
   astring@1.9.0: {}
 
   babel-dead-code-elimination@1.0.12:
     dependencies:
-      "@babel/core": 7.29.0
-      "@babel/parser": 7.29.2
-      "@babel/traverse": 7.29.0
-      "@babel/types": 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
 
   bail@2.0.2: {}
-
-  balanced-match@4.0.4: {}
-
-  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.14: {}
 
   binary-extensions@2.3.0: {}
 
-  bl@4.1.0:
-    dependencies:
-      buffer: 5.7.1
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
   blake3-wasm@2.1.5: {}
 
   boolbase@1.0.0: {}
-
-  brace-expansion@5.0.5:
-    dependencies:
-      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -6655,14 +3274,7 @@ snapshots:
       caniuse-lite: 1.0.30001785
       electron-to-chromium: 1.5.331
       node-releases: 2.0.37
-      update-browserslist-db: 1.2.3
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  callsites@3.1.0: {}
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   camelcase@6.3.0: {}
 
@@ -6708,18 +3320,6 @@ snapshots:
       undici: 7.24.7
       whatwg-mimetype: 4.0.0
 
-  chokidar@3.5.1:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.5.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
   chokidar@3.6.0:
     dependencies:
       anymatch: 3.1.3
@@ -6732,17 +3332,21 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  cli-cursor@3.1.0:
+  chokidar@5.0.0:
     dependencies:
-      restore-cursor: 3.1.0
+      readdirp: 5.0.0
 
-  cli-spinners@2.9.2: {}
-
-  cli-table@0.3.11:
+  cli-cursor@5.0.0:
     dependencies:
-      colors: 1.0.3
+      restore-cursor: 5.1.0
 
-  clone@1.0.4: {}
+  cli-spinners@3.4.0: {}
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
 
   clsx@2.1.1: {}
 
@@ -6754,32 +3358,17 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colors@1.0.3: {}
-
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
 
-  convert-source-map@2.0.0: {}
+  commander@14.0.3: {}
 
-  cookie-es@2.0.1: {}
+  convert-source-map@2.0.0: {}
 
   cookie-es@3.1.1: {}
 
   cookie@1.1.1: {}
-
-  cosmiconfig@8.3.6:
-    dependencies:
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-
-  cross-spawn@7.0.6:
-    dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -6795,8 +3384,6 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  date-fns@3.6.0: {}
-
   dayjs@1.11.20: {}
 
   debug@4.4.3:
@@ -6806,10 +3393,6 @@ snapshots:
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
-
-  defaults@1.0.4:
-    dependencies:
-      clone: 1.0.4
 
   dequal@2.0.3: {}
 
@@ -6841,6 +3424,8 @@ snapshots:
 
   electron-to-chromium@1.5.331: {}
 
+  emoji-regex@8.0.0: {}
+
   encoding-sniffer@0.2.1:
     dependencies:
       iconv-lite: 0.6.3
@@ -6857,126 +3442,47 @@ snapshots:
 
   entities@7.0.1: {}
 
-  error-ex@1.3.4:
-    dependencies:
-      is-arrayish: 0.2.1
-
   error-stack-parser-es@1.0.5: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
-      "@types/estree-jsx": 1.0.5
+      '@types/estree-jsx': 1.0.5
       devlop: 1.1.0
       estree-util-visit: 2.0.0
       unist-util-position-from-estree: 2.0.0
 
   esast-util-from-js@2.0.1:
     dependencies:
-      "@types/estree-jsx": 1.0.5
+      '@types/estree-jsx': 1.0.5
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
   esbuild@0.25.12:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.12
-      "@esbuild/android-arm": 0.25.12
-      "@esbuild/android-arm64": 0.25.12
-      "@esbuild/android-x64": 0.25.12
-      "@esbuild/darwin-arm64": 0.25.12
-      "@esbuild/darwin-x64": 0.25.12
-      "@esbuild/freebsd-arm64": 0.25.12
-      "@esbuild/freebsd-x64": 0.25.12
-      "@esbuild/linux-arm": 0.25.12
-      "@esbuild/linux-arm64": 0.25.12
-      "@esbuild/linux-ia32": 0.25.12
-      "@esbuild/linux-loong64": 0.25.12
-      "@esbuild/linux-mips64el": 0.25.12
-      "@esbuild/linux-ppc64": 0.25.12
-      "@esbuild/linux-riscv64": 0.25.12
-      "@esbuild/linux-s390x": 0.25.12
-      "@esbuild/linux-x64": 0.25.12
-      "@esbuild/netbsd-arm64": 0.25.12
-      "@esbuild/netbsd-x64": 0.25.12
-      "@esbuild/openbsd-arm64": 0.25.12
-      "@esbuild/openbsd-x64": 0.25.12
-      "@esbuild/openharmony-arm64": 0.25.12
-      "@esbuild/sunos-x64": 0.25.12
-      "@esbuild/win32-arm64": 0.25.12
-      "@esbuild/win32-ia32": 0.25.12
-      "@esbuild/win32-x64": 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.3:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.27.3
-      "@esbuild/android-arm": 0.27.3
-      "@esbuild/android-arm64": 0.27.3
-      "@esbuild/android-x64": 0.27.3
-      "@esbuild/darwin-arm64": 0.27.3
-      "@esbuild/darwin-x64": 0.27.3
-      "@esbuild/freebsd-arm64": 0.27.3
-      "@esbuild/freebsd-x64": 0.27.3
-      "@esbuild/linux-arm": 0.27.3
-      "@esbuild/linux-arm64": 0.27.3
-      "@esbuild/linux-ia32": 0.27.3
-      "@esbuild/linux-loong64": 0.27.3
-      "@esbuild/linux-mips64el": 0.27.3
-      "@esbuild/linux-ppc64": 0.27.3
-      "@esbuild/linux-riscv64": 0.27.3
-      "@esbuild/linux-s390x": 0.27.3
-      "@esbuild/linux-x64": 0.27.3
-      "@esbuild/netbsd-arm64": 0.27.3
-      "@esbuild/netbsd-x64": 0.27.3
-      "@esbuild/openbsd-arm64": 0.27.3
-      "@esbuild/openbsd-x64": 0.27.3
-      "@esbuild/openharmony-arm64": 0.27.3
-      "@esbuild/sunos-x64": 0.27.3
-      "@esbuild/win32-arm64": 0.27.3
-      "@esbuild/win32-ia32": 0.27.3
-      "@esbuild/win32-x64": 0.27.3
-
-  esbuild@0.27.7:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.27.7
-      "@esbuild/android-arm": 0.27.7
-      "@esbuild/android-arm64": 0.27.7
-      "@esbuild/android-x64": 0.27.7
-      "@esbuild/darwin-arm64": 0.27.7
-      "@esbuild/darwin-x64": 0.27.7
-      "@esbuild/freebsd-arm64": 0.27.7
-      "@esbuild/freebsd-x64": 0.27.7
-      "@esbuild/linux-arm": 0.27.7
-      "@esbuild/linux-arm64": 0.27.7
-      "@esbuild/linux-ia32": 0.27.7
-      "@esbuild/linux-loong64": 0.27.7
-      "@esbuild/linux-mips64el": 0.27.7
-      "@esbuild/linux-ppc64": 0.27.7
-      "@esbuild/linux-riscv64": 0.27.7
-      "@esbuild/linux-s390x": 0.27.7
-      "@esbuild/linux-x64": 0.27.7
-      "@esbuild/netbsd-arm64": 0.27.7
-      "@esbuild/netbsd-x64": 0.27.7
-      "@esbuild/openbsd-arm64": 0.27.7
-      "@esbuild/openbsd-x64": 0.27.7
-      "@esbuild/openharmony-arm64": 0.27.7
-      "@esbuild/sunos-x64": 0.27.7
-      "@esbuild/win32-arm64": 0.27.7
-      "@esbuild/win32-ia32": 0.27.7
-      "@esbuild/win32-x64": 0.27.7
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   escalade@3.2.0: {}
 
-  esm@3.2.25: {}
-
-  esprima@4.0.1: {}
-
   estree-util-attach-comments@3.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
 
   estree-util-build-jsx@3.0.1:
     dependencies:
-      "@types/estree-jsx": 1.0.5
+      '@types/estree-jsx': 1.0.5
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       estree-walker: 3.0.3
@@ -6985,63 +3491,53 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
     dependencies:
-      "@types/estree-jsx": 1.0.5
+      '@types/estree-jsx': 1.0.5
       astring: 1.9.0
       source-map: 0.7.6
 
   estree-util-visit@2.0.0:
     dependencies:
-      "@types/estree-jsx": 1.0.5
-      "@types/unist": 3.0.3
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
 
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
 
   exsolve@1.0.8: {}
 
   extend@3.0.2: {}
 
-  fdir@6.5.0: {}
+  fdir@6.5.0(picomatch@4.0.4):
+    dependencies:
+      picomatch: 4.0.4
+
+  fetchdts@0.1.7: {}
 
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   fsevents@2.3.3: {}
 
   gensync@1.0.0-beta.2: {}
 
-  get-tsconfig@4.13.7:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
+  get-east-asian-width@1.6.0: {}
 
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
 
-  glob@11.1.0:
+  goober@2.1.18(csstype@3.2.3):
     dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.2.3
-      minimatch: 10.2.5
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.2
-
-  goober@2.1.18: {}
+      csstype: 3.2.3
 
   graceful-fs@4.2.11: {}
 
@@ -7054,9 +3550,9 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      "@types/estree": 1.0.8
-      "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
+      '@types/estree': 1.0.8
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       estree-util-attach-comments: 3.0.0
@@ -7073,9 +3569,9 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      "@types/estree": 1.0.8
-      "@types/hast": 3.0.4
-      "@types/unist": 3.0.3
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -7091,7 +3587,7 @@ snapshots:
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      "@types/hast": 3.0.4
+      '@types/hast': 3.0.4
 
   htmlparser2@10.1.0:
     dependencies:
@@ -7104,15 +3600,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1: {}
-
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
-
-  inherits@2.0.4: {}
-
   inline-style-parser@0.2.7: {}
 
   is-alphabetical@2.0.1: {}
@@ -7122,8 +3609,6 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
-  is-arrayish@0.2.1: {}
-
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -7132,35 +3617,29 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
 
-  is-interactive@1.0.0: {}
+  is-interactive@2.0.0: {}
 
   is-number@7.0.0: {}
 
-  is-observable@2.1.0: {}
-
   is-plain-obj@4.1.0: {}
 
-  is-unicode-supported@0.1.0: {}
+  is-unicode-supported@2.1.0: {}
 
   isbot@5.1.37: {}
-
-  isexe@2.0.0: {}
-
-  jackspeak@4.2.3:
-    dependencies:
-      "@isaacs/cliui": 9.0.0
 
   jest-get-type@29.6.3: {}
 
   jest-validate@29.7.0:
     dependencies:
-      "@jest/types": 29.6.3
+      '@jest/types': 29.6.3
       camelcase: 6.3.0
       chalk: 4.1.2
       jest-get-type: 29.6.3
@@ -7168,6 +3647,8 @@ snapshots:
       pretty-format: 29.7.0
 
   jiti@2.6.1: {}
+
+  jiti@2.7.0: {}
 
   js-sha256@0.10.1: {}
 
@@ -7178,8 +3659,6 @@ snapshots:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
-
-  json-parse-even-better-errors@2.3.1: {}
 
   json5@2.2.3: {}
 
@@ -7192,19 +3671,9 @@ snapshots:
 
   lefthook-darwin-arm64@2.1.6: {}
 
-  lefthook-darwin-x64@2.1.6: {}
-
-  lefthook-freebsd-arm64@2.1.6: {}
-
-  lefthook-freebsd-x64@2.1.6: {}
-
   lefthook-linux-arm64@2.1.6: {}
 
   lefthook-linux-x64@2.1.6: {}
-
-  lefthook-openbsd-arm64@2.1.6: {}
-
-  lefthook-openbsd-x64@2.1.6: {}
 
   lefthook-windows-arm64@2.1.6: {}
 
@@ -7213,27 +3682,14 @@ snapshots:
   lefthook@2.1.6:
     optionalDependencies:
       lefthook-darwin-arm64: 2.1.6
-      lefthook-darwin-x64: 2.1.6
-      lefthook-freebsd-arm64: 2.1.6
-      lefthook-freebsd-x64: 2.1.6
       lefthook-linux-arm64: 2.1.6
       lefthook-linux-x64: 2.1.6
-      lefthook-openbsd-arm64: 2.1.6
-      lefthook-openbsd-x64: 2.1.6
       lefthook-windows-arm64: 2.1.6
       lefthook-windows-x64: 2.1.6
 
   leven@3.1.0: {}
 
-  lightningcss-android-arm64@1.32.0: {}
-
   lightningcss-darwin-arm64@1.32.0: {}
-
-  lightningcss-darwin-x64@1.32.0: {}
-
-  lightningcss-freebsd-x64@1.32.0: {}
-
-  lightningcss-linux-arm-gnueabihf@1.32.0: {}
 
   lightningcss-linux-arm64-gnu@1.32.0: {}
 
@@ -7251,11 +3707,7 @@ snapshots:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
       lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
       lightningcss-linux-arm64-gnu: 1.32.0
       lightningcss-linux-arm64-musl: 1.32.0
       lightningcss-linux-x64-gnu: 1.32.0
@@ -7265,16 +3717,12 @@ snapshots:
 
   lilconfig@3.1.3: {}
 
-  lines-and-columns@1.2.4: {}
-
-  log-symbols@4.1.0:
+  log-symbols@7.0.1:
     dependencies:
-      chalk: 4.1.2
-      is-unicode-supported: 0.1.0
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
 
   longest-streak@3.1.0: {}
-
-  lru-cache@11.2.7: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -7282,14 +3730,14 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      "@jridgewell/sourcemap-codec": 1.5.5
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   markdown-extensions@2.0.0: {}
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
-      "@types/mdast": 4.0.4
-      "@types/unist": 3.0.3
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
@@ -7303,19 +3751,19 @@ snapshots:
 
   mdast-util-mdx-expression@2.0.1:
     dependencies:
-      "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
 
   mdast-util-mdx-jsx@3.2.0:
     dependencies:
-      "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
-      "@types/unist": 3.0.3
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
@@ -7335,23 +3783,23 @@ snapshots:
 
   mdast-util-mdxjs-esm@2.0.1:
     dependencies:
-      "@types/estree-jsx": 1.0.5
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       devlop: 1.1.0
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
 
   mdast-util-phrasing@4.1.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       unist-util-is: 6.0.1
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
-      "@ungap/structured-clone": 1.3.0
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -7361,8 +3809,8 @@ snapshots:
 
   mdast-util-to-markdown@2.1.2:
     dependencies:
-      "@types/mdast": 4.0.4
-      "@types/unist": 3.0.3
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
       longest-streak: 3.1.0
       mdast-util-phrasing: 4.1.0
       mdast-util-to-string: 4.0.0
@@ -7373,7 +3821,7 @@ snapshots:
 
   mdast-util-to-string@4.0.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -7396,7 +3844,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -7407,7 +3855,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -7424,7 +3872,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -7434,10 +3882,10 @@ snapshots:
       unist-util-position-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  micromark-extension-mdxjs@3.0.0:
+  micromark-extension-mdxjs@3.0.0(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
-      acorn-jsx: 5.3.2
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -7460,7 +3908,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -7524,8 +3972,8 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      "@types/estree": 1.0.8
-      "@types/unist": 3.0.3
+      '@types/estree': 1.0.8
+      '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
       micromark-util-symbol: 2.0.1
@@ -7561,7 +4009,7 @@ snapshots:
 
   micromark@4.0.2:
     dependencies:
-      "@types/debug": 4.1.13
+      '@types/debug': 4.1.13
       debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
@@ -7584,22 +4032,16 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
-  mimic-fn@2.1.0: {}
+  mimic-function@5.0.1: {}
 
-  miniflare@4.20260507.1:
+  miniflare@4.20260511.0:
     dependencies:
-      "@cspotcode/source-map-support": 0.8.1
+      '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.24.8
-      workerd: 1.20260507.1
+      workerd: 1.20260511.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
-
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.5
-
-  minipass@7.1.3: {}
 
   moo@0.5.3: {}
 
@@ -7615,92 +4057,64 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  observable-fns@0.6.1: {}
-
-  onetime@5.1.2:
+  onetime@7.0.0:
     dependencies:
-      mimic-fn: 2.1.0
+      mimic-function: 5.0.1
 
-  ora@5.4.1:
+  ora@9.4.0:
     dependencies:
-      bl: 4.1.0
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-spinners: 2.9.2
-      is-interactive: 1.0.0
-      is-unicode-supported: 0.1.0
-      log-symbols: 4.1.0
-      strip-ansi: 6.0.1
-      wcwidth: 1.0.1
+      chalk: 5.6.2
+      cli-cursor: 5.0.0
+      cli-spinners: 3.4.0
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.1.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.1
 
-  oxfmt@0.48.0:
+  oxc-parser@0.120.0:
+    dependencies:
+      '@oxc-project/types': 0.120.0
+    optionalDependencies:
+      '@oxc-parser/binding-darwin-arm64': 0.120.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.120.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.120.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.120.0
+      '@oxc-parser/binding-linux-x64-musl': 0.120.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.120.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.120.0
+
+  oxfmt@0.49.0:
     dependencies:
       tinypool: 2.1.0
     optionalDependencies:
-      "@oxfmt/binding-android-arm-eabi": 0.48.0
-      "@oxfmt/binding-android-arm64": 0.48.0
-      "@oxfmt/binding-darwin-arm64": 0.48.0
-      "@oxfmt/binding-darwin-x64": 0.48.0
-      "@oxfmt/binding-freebsd-x64": 0.48.0
-      "@oxfmt/binding-linux-arm-gnueabihf": 0.48.0
-      "@oxfmt/binding-linux-arm-musleabihf": 0.48.0
-      "@oxfmt/binding-linux-arm64-gnu": 0.48.0
-      "@oxfmt/binding-linux-arm64-musl": 0.48.0
-      "@oxfmt/binding-linux-ppc64-gnu": 0.48.0
-      "@oxfmt/binding-linux-riscv64-gnu": 0.48.0
-      "@oxfmt/binding-linux-riscv64-musl": 0.48.0
-      "@oxfmt/binding-linux-s390x-gnu": 0.48.0
-      "@oxfmt/binding-linux-x64-gnu": 0.48.0
-      "@oxfmt/binding-linux-x64-musl": 0.48.0
-      "@oxfmt/binding-openharmony-arm64": 0.48.0
-      "@oxfmt/binding-win32-arm64-msvc": 0.48.0
-      "@oxfmt/binding-win32-ia32-msvc": 0.48.0
-      "@oxfmt/binding-win32-x64-msvc": 0.48.0
+      '@oxfmt/binding-darwin-arm64': 0.49.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.49.0
+      '@oxfmt/binding-linux-arm64-musl': 0.49.0
+      '@oxfmt/binding-linux-x64-gnu': 0.49.0
+      '@oxfmt/binding-linux-x64-musl': 0.49.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.49.0
+      '@oxfmt/binding-win32-x64-msvc': 0.49.0
 
-  oxlint@1.63.0:
+  oxlint@1.64.0:
     optionalDependencies:
-      "@oxlint/binding-android-arm-eabi": 1.63.0
-      "@oxlint/binding-android-arm64": 1.63.0
-      "@oxlint/binding-darwin-arm64": 1.63.0
-      "@oxlint/binding-darwin-x64": 1.63.0
-      "@oxlint/binding-freebsd-x64": 1.63.0
-      "@oxlint/binding-linux-arm-gnueabihf": 1.63.0
-      "@oxlint/binding-linux-arm-musleabihf": 1.63.0
-      "@oxlint/binding-linux-arm64-gnu": 1.63.0
-      "@oxlint/binding-linux-arm64-musl": 1.63.0
-      "@oxlint/binding-linux-ppc64-gnu": 1.63.0
-      "@oxlint/binding-linux-riscv64-gnu": 1.63.0
-      "@oxlint/binding-linux-riscv64-musl": 1.63.0
-      "@oxlint/binding-linux-s390x-gnu": 1.63.0
-      "@oxlint/binding-linux-x64-gnu": 1.63.0
-      "@oxlint/binding-linux-x64-musl": 1.63.0
-      "@oxlint/binding-openharmony-arm64": 1.63.0
-      "@oxlint/binding-win32-arm64-msvc": 1.63.0
-      "@oxlint/binding-win32-ia32-msvc": 1.63.0
-      "@oxlint/binding-win32-x64-msvc": 1.63.0
-
-  package-json-from-dist@1.0.1: {}
-
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
+      '@oxlint/binding-darwin-arm64': 1.64.0
+      '@oxlint/binding-linux-arm64-gnu': 1.64.0
+      '@oxlint/binding-linux-arm64-musl': 1.64.0
+      '@oxlint/binding-linux-x64-gnu': 1.64.0
+      '@oxlint/binding-linux-x64-musl': 1.64.0
+      '@oxlint/binding-win32-arm64-msvc': 1.64.0
+      '@oxlint/binding-win32-x64-msvc': 1.64.0
 
   parse-entities@4.0.2:
     dependencies:
-      "@types/unist": 2.0.11
+      '@types/unist': 2.0.11
       character-entities-legacy: 3.0.0
       character-reference-invalid: 2.0.1
       decode-named-character-reference: 1.3.0
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
-
-  parse-json@5.2.0:
-    dependencies:
-      "@babel/code-frame": 7.29.0
-      error-ex: 1.3.4
-      json-parse-even-better-errors: 2.3.1
-      lines-and-columns: 1.2.4
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
@@ -7715,16 +4129,7 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  path-key@3.1.1: {}
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.2.7
-      minipass: 7.1.3
-
   path-to-regexp@6.3.0: {}
-
-  path-type@4.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -7751,7 +4156,7 @@ snapshots:
 
   pretty-format@29.7.0:
     dependencies:
-      "@jest/schemas": 29.6.3
+      '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
@@ -7761,45 +4166,31 @@ snapshots:
     dependencies:
       commander: 10.0.1
 
-  react-dom@19.2.4:
+  react-dom@19.2.6(react@19.2.6):
     dependencies:
+      react: 19.2.6
       scheduler: 0.27.0
 
   react-is@18.3.1: {}
 
-  react@19.2.4: {}
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
-
-  readdirp@3.5.0:
-    dependencies:
-      picomatch: 2.3.2
+  react@19.2.6: {}
 
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
 
-  recast@0.23.11:
-    dependencies:
-      ast-types: 0.16.1
-      esprima: 4.0.1
-      source-map: 0.6.1
-      tiny-invariant: 1.3.3
-      tslib: 2.8.1
+  readdirp@5.0.0: {}
 
   recma-build-jsx@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1:
+  recma-jsx@1.0.1(acorn@8.16.0):
     dependencies:
-      acorn-jsx: 5.3.2
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -7807,108 +4198,77 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
 
   rehype-recma@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
-      "@types/hast": 3.0.4
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
 
-  remark-mdx@3.1.1:
+  remark-mdx@3.1.1(acorn@8.16.0):
     dependencies:
       mdast-util-mdx: 3.0.0
-      micromark-extension-mdxjs: 3.0.0
+      micromark-extension-mdxjs: 3.0.0(acorn@8.16.0)
 
   remark-parse@11.0.0:
     dependencies:
-      "@types/mdast": 4.0.4
+      '@types/mdast': 4.0.4
       mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
 
   remark-rehype@11.1.2:
     dependencies:
-      "@types/hast": 3.0.4
-      "@types/mdast": 4.0.4
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
 
-  resolve-from@4.0.0: {}
-
-  resolve-pkg-maps@1.0.0: {}
-
-  restore-cursor@3.1.0:
+  restore-cursor@5.1.0:
     dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
+      onetime: 7.0.0
+      signal-exit: 4.1.0
 
-  rolldown@1.0.0-rc.18:
+  rolldown@1.0.1:
     dependencies:
-      "@oxc-project/types": 0.128.0
-      "@rolldown/pluginutils": 1.0.0-rc.18
+      '@oxc-project/types': 0.130.0
+      '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      "@rolldown/binding-android-arm64": 1.0.0-rc.18
-      "@rolldown/binding-darwin-arm64": 1.0.0-rc.18
-      "@rolldown/binding-darwin-x64": 1.0.0-rc.18
-      "@rolldown/binding-freebsd-x64": 1.0.0-rc.18
-      "@rolldown/binding-linux-arm-gnueabihf": 1.0.0-rc.18
-      "@rolldown/binding-linux-arm64-gnu": 1.0.0-rc.18
-      "@rolldown/binding-linux-arm64-musl": 1.0.0-rc.18
-      "@rolldown/binding-linux-ppc64-gnu": 1.0.0-rc.18
-      "@rolldown/binding-linux-s390x-gnu": 1.0.0-rc.18
-      "@rolldown/binding-linux-x64-gnu": 1.0.0-rc.18
-      "@rolldown/binding-linux-x64-musl": 1.0.0-rc.18
-      "@rolldown/binding-openharmony-arm64": 1.0.0-rc.18
-      "@rolldown/binding-wasm32-wasi": 1.0.0-rc.18
-      "@rolldown/binding-win32-arm64-msvc": 1.0.0-rc.18
-      "@rolldown/binding-win32-x64-msvc": 1.0.0-rc.18
+      '@rolldown/binding-darwin-arm64': 1.0.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.1
+      '@rolldown/binding-linux-x64-musl': 1.0.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.1
 
   rollup@4.60.1:
     dependencies:
-      "@types/estree": 1.0.8
+      '@types/estree': 1.0.8
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.60.1
-      "@rollup/rollup-android-arm64": 4.60.1
-      "@rollup/rollup-darwin-arm64": 4.60.1
-      "@rollup/rollup-darwin-x64": 4.60.1
-      "@rollup/rollup-freebsd-arm64": 4.60.1
-      "@rollup/rollup-freebsd-x64": 4.60.1
-      "@rollup/rollup-linux-arm-gnueabihf": 4.60.1
-      "@rollup/rollup-linux-arm-musleabihf": 4.60.1
-      "@rollup/rollup-linux-arm64-gnu": 4.60.1
-      "@rollup/rollup-linux-arm64-musl": 4.60.1
-      "@rollup/rollup-linux-loong64-gnu": 4.60.1
-      "@rollup/rollup-linux-loong64-musl": 4.60.1
-      "@rollup/rollup-linux-ppc64-gnu": 4.60.1
-      "@rollup/rollup-linux-ppc64-musl": 4.60.1
-      "@rollup/rollup-linux-riscv64-gnu": 4.60.1
-      "@rollup/rollup-linux-riscv64-musl": 4.60.1
-      "@rollup/rollup-linux-s390x-gnu": 4.60.1
-      "@rollup/rollup-linux-x64-gnu": 4.60.1
-      "@rollup/rollup-linux-x64-musl": 4.60.1
-      "@rollup/rollup-openbsd-x64": 4.60.1
-      "@rollup/rollup-openharmony-arm64": 4.60.1
-      "@rollup/rollup-win32-arm64-msvc": 4.60.1
-      "@rollup/rollup-win32-ia32-msvc": 4.60.1
-      "@rollup/rollup-win32-x64-gnu": 4.60.1
-      "@rollup/rollup-win32-x64-msvc": 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
   rou3@0.8.1: {}
-
-  safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
 
@@ -7918,62 +4278,48 @@ snapshots:
 
   semver@7.8.0: {}
 
-  seroval-plugins@1.5.2: {}
+  seroval-plugins@1.5.2(seroval@1.5.2):
+    dependencies:
+      seroval: 1.5.2
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
 
   seroval@1.5.2: {}
 
+  seroval@1.5.4: {}
+
   sharp@0.34.5:
     dependencies:
-      "@img/colour": 1.1.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.0
     optionalDependencies:
-      "@img/sharp-darwin-arm64": 0.34.5
-      "@img/sharp-darwin-x64": 0.34.5
-      "@img/sharp-libvips-darwin-arm64": 1.2.4
-      "@img/sharp-libvips-darwin-x64": 1.2.4
-      "@img/sharp-libvips-linux-arm": 1.2.4
-      "@img/sharp-libvips-linux-arm64": 1.2.4
-      "@img/sharp-libvips-linux-ppc64": 1.2.4
-      "@img/sharp-libvips-linux-riscv64": 1.2.4
-      "@img/sharp-libvips-linux-s390x": 1.2.4
-      "@img/sharp-libvips-linux-x64": 1.2.4
-      "@img/sharp-libvips-linuxmusl-arm64": 1.2.4
-      "@img/sharp-libvips-linuxmusl-x64": 1.2.4
-      "@img/sharp-linux-arm": 0.34.5
-      "@img/sharp-linux-arm64": 0.34.5
-      "@img/sharp-linux-ppc64": 0.34.5
-      "@img/sharp-linux-riscv64": 0.34.5
-      "@img/sharp-linux-s390x": 0.34.5
-      "@img/sharp-linux-x64": 0.34.5
-      "@img/sharp-linuxmusl-arm64": 0.34.5
-      "@img/sharp-linuxmusl-x64": 0.34.5
-      "@img/sharp-wasm32": 0.34.5
-      "@img/sharp-win32-arm64": 0.34.5
-      "@img/sharp-win32-ia32": 0.34.5
-      "@img/sharp-win32-x64": 0.34.5
-
-  shebang-command@2.0.0:
-    dependencies:
-      shebang-regex: 3.0.0
-
-  shebang-regex@3.0.0: {}
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
 
   shell-quote@1.8.3: {}
 
-  signal-exit@3.0.7: {}
-
   signal-exit@4.1.0: {}
 
-  solid-js@1.9.12:
+  solid-js@1.9.12(seroval@1.5.2):
     dependencies:
       csstype: 3.2.3
       seroval: 1.5.2
-      seroval-plugins: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
 
   source-map-js@1.2.1: {}
-
-  source-map@0.6.1: {}
 
   source-map@0.7.6: {}
 
@@ -7981,9 +4327,18 @@ snapshots:
 
   srvx@0.11.15: {}
 
-  string_decoder@1.3.0:
+  stdin-discarder@0.3.2: {}
+
+  string-width@4.2.3:
     dependencies:
-      safe-buffer: 5.2.1
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
 
   stringify-entities@4.0.4:
     dependencies:
@@ -7993,6 +4348,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   style-to-js@1.1.21:
     dependencies:
@@ -8008,35 +4367,17 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tailwindcss-logical@4.2.0: {}
+  tailwindcss-logical@4.2.0(tailwindcss@4.3.0):
+    dependencies:
+      tailwindcss: 4.3.0
 
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
 
-  threads@1.7.0:
+  tinyglobby@0.2.16(picomatch@4.0.4):
     dependencies:
-      callsites: 3.1.0
-      debug: 4.4.3
-      is-observable: 2.1.0
-      observable-fns: 0.6.1
-    optionalDependencies:
-      tiny-worker: 2.3.0
-
-  tiny-invariant@1.3.3: {}
-
-  tiny-worker@2.3.0:
-    dependencies:
-      esm: 3.2.25
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0
-      picomatch: 4.0.4
-
-  tinyglobby@0.2.16:
-    dependencies:
-      fdir: 6.5.0
+      fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
   tinypool@2.1.0: {}
@@ -8048,15 +4389,6 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
-
-  tslib@2.8.1: {}
-
-  tsx@4.21.0:
-    dependencies:
-      esbuild: 0.27.7
-      get-tsconfig: 4.13.7
-    optionalDependencies:
-      fsevents: 2.3.3
 
   typescript@6.0.3: {}
 
@@ -8074,7 +4406,7 @@ snapshots:
 
   unified@11.0.5:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       bail: 2.0.2
       devlop: 1.1.0
       extend: 3.0.2
@@ -8084,78 +4416,75 @@ snapshots:
 
   unist-util-is@6.0.1:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
   unist-util-position-from-estree@2.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
   unist-util-position@5.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
   unist-util-stringify-position@4.0.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
 
   unist-util-visit-parents@6.0.2:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
   unist-util-visit@5.1.0:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unplugin@2.3.11:
-    dependencies:
-      "@jridgewell/remapping": 2.3.5
-      acorn: 8.16.0
-      picomatch: 4.0.4
-      webpack-virtual-modules: 0.6.2
-
   unplugin@3.0.0:
     dependencies:
-      "@jridgewell/remapping": 2.3.5
+      '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  update-browserslist-db@1.2.3:
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
+      browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  use-sync-external-store@1.6.0: {}
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   util-deprecate@1.0.2: {}
 
   vfile-message@4.0.3:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
 
   vfile@6.0.3:
     dependencies:
-      "@types/unist": 3.0.3
+      '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.0.11:
+  vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0):
     dependencies:
+      '@types/node': 25.5.2
+      esbuild: 0.27.3
+      jiti: 2.7.0
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.14
-      rolldown: 1.0.0-rc.18
-      tinyglobby: 0.2.16
+      rolldown: 1.0.1
+      tinyglobby: 0.2.16(picomatch@4.0.4)
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitefu@1.1.3: {}
-
-  wcwidth@1.0.1:
+  vitefu@1.1.3(vite@8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)):
     dependencies:
-      defaults: 1.0.4
+      vite: 8.0.13(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.7.0)
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -8165,28 +4494,23 @@ snapshots:
 
   whatwg-mimetype@4.0.0: {}
 
-  which@2.0.2:
-    dependencies:
-      isexe: 2.0.0
-
-  workerd@1.20260507.1:
+  workerd@1.20260511.1:
     optionalDependencies:
-      "@cloudflare/workerd-darwin-64": 1.20260507.1
-      "@cloudflare/workerd-darwin-arm64": 1.20260507.1
-      "@cloudflare/workerd-linux-64": 1.20260507.1
-      "@cloudflare/workerd-linux-arm64": 1.20260507.1
-      "@cloudflare/workerd-windows-64": 1.20260507.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260511.1
+      '@cloudflare/workerd-linux-64': 1.20260511.1
+      '@cloudflare/workerd-linux-arm64': 1.20260511.1
+      '@cloudflare/workerd-windows-64': 1.20260511.1
 
-  wrangler@4.90.0:
+  wrangler@4.91.0:
     dependencies:
-      "@cloudflare/kv-asset-handler": 0.5.0
-      "@cloudflare/unenv-preset": 2.16.1
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260507.1
+      miniflare: 4.20260511.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260507.1
+      workerd: 1.20260511.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -8196,23 +4520,25 @@ snapshots:
 
   xmlbuilder2@4.0.3:
     dependencies:
-      "@oozcitak/dom": 2.0.2
-      "@oozcitak/infra": 2.0.2
-      "@oozcitak/util": 10.0.0
+      '@oozcitak/dom': 2.0.2
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/util': 10.0.0
       js-yaml: 4.1.1
 
   yallist@3.1.1: {}
 
+  yoctocolors@2.1.2: {}
+
   youch-core@0.3.3:
     dependencies:
-      "@poppinss/exception": 1.2.3
+      '@poppinss/exception': 1.2.3
       error-stack-parser-es: 1.0.5
 
   youch@4.1.0-beta.10:
     dependencies:
-      "@poppinss/colors": 4.1.6
-      "@poppinss/dumper": 0.6.5
-      "@speed-highlight/core": 1.2.15
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
       cookie: 1.1.1
       youch-core: 0.3.3
 

--- a/lingui.config.ts
+++ b/lingui.config.ts
@@ -11,5 +11,4 @@ export default defineConfig({
       exclude: ["**/node_modules/**"],
     },
   ],
-  format: "po",
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lingui:extract": "lingui extract"
   },
   "dependencies": {
-    "@cloudflare/vite-plugin": "^1.36.3",
+    "@cloudflare/vite-plugin": "^1.37.0",
     "@lingui/core": "^6.0.1",
     "@lingui/react": "^6.0.1",
     "@tanstack/react-devtools": "latest",
@@ -26,13 +26,13 @@
     "@tanstack/react-router-devtools": "latest",
     "@tanstack/react-router-ssr-query": "latest",
     "@tanstack/react-start": "latest",
-    "@tanstack/router-plugin": "^1.132.0",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "@tanstack/router-plugin": "^1.167.35",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
   },
   "devDependencies": {
-    "@lingui/cli": "^5.9.4",
-    "@lingui/vite-plugin": "^5.9.4",
+    "@lingui/cli": "^6.0.1",
+    "@lingui/vite-plugin": "^6.0.1",
     "@mdx-js/rollup": "^3.1.1",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.3.0",
@@ -40,14 +40,14 @@
     "@types/mdx": "^2.0.13",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.1",
+    "@vitejs/plugin-react": "^6.0.2",
     "lefthook": "^2.1.6",
-    "oxfmt": "^0.48.0",
-    "oxlint": "^1.63.0",
+    "oxfmt": "^0.49.0",
+    "oxlint": "^1.64.0",
     "tailwindcss": "^4.3.0",
     "tailwindcss-logical": "^4.2.0",
     "typescript": "~6.0.3",
-    "vite": "^8.0.11",
-    "wrangler": "^4.90.0"
+    "vite": "^8.0.13",
+    "wrangler": "^4.91.0"
   }
 }

--- a/src/locales/am-ET/messages.po
+++ b/src/locales/am-ET/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ጄምስ ክሊቭላንድ : ከፍተኛ የሙሉ ስታክ መሐንዲስ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ጄምስ ክሊቭላንድ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/ar-EG/messages.po
+++ b/src/locales/ar-EG/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "جيمس كليفلاند : مهندس فول ستاك كبير"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "جيمس كليفلاند"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "السيرة الذاتية-٢٠٢٥.٠١"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "غيت هاب"

--- a/src/locales/ar-PS/messages.po
+++ b/src/locales/ar-PS/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "جيمس كليفلاند : مهندس فول ستاك كبير"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "جيمس كليفلاند"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "السيرة الذاتية-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "غيت هاب"

--- a/src/locales/bn-BD/messages.po
+++ b/src/locales/bn-BD/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "জেমস ক্লিভল্যান্ড : সিনিয়র ফুল স্ট্যাক ইঞ্জিনিয়ার"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "জেমস ক্লিভল্যান্ড"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/bo-CN/messages.po
+++ b/src/locales/bo-CN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ཇེམས་ཀི་ལིཝ་ལེནཌ་ : སིནིཡར་ཕུལ་སི་ཊེཀ་ ཨིན་ཇི་ནིཡར་"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ཇེམས་ཀི་ལིཝ་ལེནཌ་"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/de-DE/messages.po
+++ b/src/locales/de-DE/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "james cleveland : senior full stack ingenieur"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "james cleveland"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "lebenslauf-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/dv-MV/messages.po
+++ b/src/locales/dv-MV/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ޖޭމްސް ކްލީވްލޭންޑް : ސީނިއަރ ފުލް ސްޓެކް އިންޖިނިއަރ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ޖޭމްސް ކްލީވްލޭންޑް"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/el-GR/messages.po
+++ b/src/locales/el-GR/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "Τζέιμς Κλίβελαντ : ανώτερος full stack μηχανικός"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "Τζέιμς Κλίβελαντ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/en-GB/messages.po
+++ b/src/locales/en-GB/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "james cleveland : senior full stack engineer"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "james cleveland"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/fr-FR/messages.po
+++ b/src/locales/fr-FR/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "james cleveland : ingénieur full stack senior"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "james cleveland"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/gu-IN/messages.po
+++ b/src/locales/gu-IN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "જેમ્સ ક્લીવલેન્ડ : વરિષ્ઠ ફુલ સ્ટેક એન્જિનિયર"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "જેમ્સ ક્લીવલેન્ડ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/hi-IN/messages.po
+++ b/src/locales/hi-IN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "जेम्स क्लीवलैंड : सीनियर फुल स्टैक इंजीनियर"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "जेम्स क्लीवलैंड"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/hy-AM/messages.po
+++ b/src/locales/hy-AM/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "Ջեյմս Քլիվլենդ : ավագ ֆուլ սթեք ինժեներ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "Ջեյմս Քլիվլենդ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/it-IT/messages.po
+++ b/src/locales/it-IT/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "james cleveland : ingegnere full stack senior"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "james cleveland"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "curriculum-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/ja-JP/messages.po
+++ b/src/locales/ja-JP/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ジェームス・クリーブランド：シニアフルスタックエンジニア"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ジェームス・クリーブランド"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "履歴書-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "ギットハブ"

--- a/src/locales/ka-GE/messages.po
+++ b/src/locales/ka-GE/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ჯეიმს კლივლენდი : უფროსი ფულ-სტეკ ინჟინერი"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ჯეიმს კლივლენდი"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "რეზიუმე-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "გითჰაბი"

--- a/src/locales/km-KH/messages.po
+++ b/src/locales/km-KH/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ជេមស៍ ឃ្លីវលែនដ៍ : វិស្វករ Full Stack ជាន់ខ្ពស់"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ជេមស៍ ឃ្លីវលែនដ៍"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/kn-IN/messages.po
+++ b/src/locales/kn-IN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ಜೇಮ್ಸ್ ಕ್ಲೀವ್‌ಲ್ಯಾಂಡ್ : ಸೀನಿಯರ್ ಫುಲ್ ಸ್ಟಾಕ್ ಇಂಜಿನಿಯರ್"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ಜೇಮ್ಸ್ ಕ್ಲೀವ್‌ಲ್ಯಾಂಡ್"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/ko-KR/messages.po
+++ b/src/locales/ko-KR/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "제임스 클리블랜드 : 시니어 풀스택 엔지니어"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "제임스 클리블랜드"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/lo-LA/messages.po
+++ b/src/locales/lo-LA/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ເຈມສ໌ ຄລີຟແລນດ໌ : ວິສະວະກອນ Full Stack ອາວຸໂສ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ເຈມສ໌ ຄລີຟແລນດ໌"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/ml-IN/messages.po
+++ b/src/locales/ml-IN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ജെയിംസ് ക്ലീവ്‌ലാൻഡ് : സീനിയർ ഫുൾ സ്റ്റാക്ക് എഞ്ചിനീയർ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ജെയിംസ് ക്ലീവ്‌ലാൻഡ്"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/mn-MN/messages.po
+++ b/src/locales/mn-MN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "Жэймс Кливленд : ахлах фулл стэк инженер"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "Жэймс Кливленд"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/my-MM/messages.po
+++ b/src/locales/my-MM/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ဂျေးမ်စ် ကလီဗလန်ဒ် : အကြီးတန်း ဖူးလ်စတက် အင်ဂျင်နီယာ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ဂျေးမ်စ် ကလီဗလန်ဒ်"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/ne-NP/messages.po
+++ b/src/locales/ne-NP/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "जेम्स क्लिभल्यान्ड : सिनियर फुल स्ट्याक इन्जिनियर"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "जेम्स क्लिभल्यान्ड"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/nl-BE/messages.po
+++ b/src/locales/nl-BE/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "james cleveland : senior full stack ingenieur"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "james cleveland"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/nl-NL/messages.po
+++ b/src/locales/nl-NL/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "james cleveland : senior full stack ingenieur"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "james cleveland"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/or-IN/messages.po
+++ b/src/locales/or-IN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ଜେମ୍ସ କ୍ଲିଭଲ୍ୟାଣ୍ଡ : ସିନିଅର ଫୁଲ ଷ୍ଟାକ ଇଞ୍ଜିନିଅର"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ଜେମ୍ସ କ୍ଲିଭଲ୍ୟାଣ୍ଡ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/pa-IN/messages.po
+++ b/src/locales/pa-IN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ਜੇਮਸ ਕਲੀਵਲੈਂਡ : ਸੀਨੀਅਰ ਫੁਲ ਸਟੈਕ ਇੰਜੀਨੀਅਰ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ਜੇਮਸ ਕਲੀਵਲੈਂਡ"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/pl-PL/messages.po
+++ b/src/locales/pl-PL/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "james cleveland : starszy inżynier full stack"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "james cleveland"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/si-LK/messages.po
+++ b/src/locales/si-LK/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ජේම්ස් ක්ලීව්ලන්ඩ් : සීනියර් ෆුල් ස්ටැක් ඉංජිනේරු"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ජේම්ස් ක්ලීව්ලන්ඩ්"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/ta-IN/messages.po
+++ b/src/locales/ta-IN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "ஜேம்ஸ் கிளீவ்லாந்து : சீனியர் ஃபுல் ஸ்டேக் என்ஜினியர்"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "ஜேம்ஸ் கிளீவ்லாந்து"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/te-IN/messages.po
+++ b/src/locales/te-IN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "జేమ్స్ క్లీవ్‌ల్యాండ్ : సీనియర్ ఫుల్ స్టాక్ ఇంజనీర్"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "జేమ్స్ క్లీవ్‌ల్యాండ్"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/th-TH/messages.po
+++ b/src/locales/th-TH/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "เจมส์ คลีฟแลนด์ : วิศวกรฟูลสแตกอาวุโส"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "เจมส์ คลีฟแลนด์"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/uk-UA/messages.po
+++ b/src/locales/uk-UA/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "джеймс клівленд : старший full stack інженер"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "джеймс клівленд"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "резюме-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "гітхаб"

--- a/src/locales/vi-VN/messages.po
+++ b/src/locales/vi-VN/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "James Cleveland : kỹ sư full stack cao cấp"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "James Cleveland"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "cv-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/zh-CN/messages.po
+++ b/src/locales/zh-CN/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "詹姆斯·克利夫兰：高级全栈工程师"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "詹姆斯·克利夫兰"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "简历-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"

--- a/src/locales/zh-TW/messages.po
+++ b/src/locales/zh-TW/messages.po
@@ -14,23 +14,23 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:14
-#: src/routes/__root.tsx:16
-#: src/routes/__root.tsx:24
+#: src/routes/__root.tsx:15
+#: src/routes/__root.tsx:23
+#: src/routes/{-$locale}/index.tsx:17
 msgid "james cleveland : senior full stack engineer"
 msgstr "詹姆斯·克利夫蘭：資深全端工程師"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:13
+#: src/routes/{-$locale}/index.tsx:16
 msgid "james cleveland"
 msgstr "詹姆斯·克利夫蘭"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:16
+#: src/routes/{-$locale}/index.tsx:19
 msgid "cv-2025.01"
 msgstr "履歷-2025.01"
 
 #. js-lingui-explicit-id
-#: src/components/home-content.tsx:18
+#: src/routes/{-$locale}/index.tsx:22
 msgid "github"
 msgstr "github"


### PR DESCRIPTION
## Summary

Routine dep maintenance, plus two majors handled in-PR.

### Major bumps

- **@lingui/cli + @lingui/vite-plugin: 5.9.5 -> 6.0.1**
  - ESM-only, Node 22.19+ (we're on 24 — fine).
  - Format API changed in v6: `format: "po"` (string) is no longer accepted. Since we had no `formatOptions`, dropped the `format` line entirely — v6 defaults to `po`.
  - Refreshed `.po` source-location comments via `lingui extract`. No msgid / msgstr edits; only `#:` reference comments were updated to reflect the current file layout (left over from an earlier route move). msgs / translations untouched.
- **@tanstack/devtools-vite: 0.6.0 -> 0.7.0**
  - No code changes needed. Our usage in `vite.config.ts` is just `devtools()`.

### Within-semver

`@cloudflare/vite-plugin` 1.37.0, `@tanstack/router-plugin` 1.167.35, `@tanstack/react-router` 1.169.2, `@tanstack/react-start` 1.167.65, `@tanstack/react-devtools` 0.10.5, `@vitejs/plugin-react` 6.0.2, `oxlint` 1.64.0, `oxfmt` 0.49.0, `react` + `react-dom` 19.2.6, `vite` 8.0.13, `wrangler` 4.91.0, plus minor Lingui patch deltas before the v6 jump.

## Test plan

- [x] `aube run lint` — 0 warnings, 0 errors
- [x] `aube run typecheck` — clean
- [x] `aube run build` — 76 prerendered pages (37 locales x 2 + root)
- [x] `aube run lingui:extract` — runs under v6 with new defaulted formatter