### PR TITLE
ci: make the Taskfile the pipeline and Actions just the environment

### DIFF
--- a/.github/workflows/publish-web-container.yml
+++ b/.github/workflows/publish-web-container.yml
@@ -48,11 +48,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      # Exposes ACTIONS_RUNTIME_TOKEN and friends so `--cache-to type=gha` works
-      # from the buildx CLI rather than only inside build-push-action.
-      - name: Expose Actions runtime for the buildx cache
-        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4
-
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -61,10 +56,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # No cache is configured: the image is a FROM, a LABEL and a COPY of dist/, whose
+      # content changes on every build. Set CACHE_FROM/CACHE_TO here if it ever grows a
+      # build stage worth caching — the Taskfile already reads them.
       - name: Build container image
-        env:
-          CACHE_FROM: type=gha
-          CACHE_TO: type=gha,mode=max
         run: >-
           task docker:build
           SHA=${{ github.sha }}
@@ -75,6 +70,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main'
+
+    # Serialised because the job clones jaritanet fresh, commits and pushes; two racing
+    # means the loser is rejected non-fast-forward with no way to recover in-job. A
+    # superseded run is cancelled rather than queued — it would only push a tag the
+    # newer run is about to replace.
+    concurrency:
+      group: deploy-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/publish-web-container.yml
+++ b/.github/workflows/publish-web-container.yml
@@ -1,11 +1,8 @@
 name: Build and Deploy Blit
 
-env:
-  PROJECT_NAME: blit
-  ACCOUNT: radiosilence
-  DEPLOYMENT_REPO: jaritanet
-  DEPLOYMENT_BRANCH: main
-  DEPLOYMENT_CONFIG_PATH: packages/infra/Pulumi.main.yaml
+# This workflow supplies an environment — a checkout, a toolchain, registry
+# credentials and a build cache — and nothing else. Every step of substance is a
+# Taskfile target that runs identically on a laptop.
 
 permissions:
   contents: read
@@ -33,21 +30,12 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      # mise.toml is the single source of truth for node, aube and task.
+      # mise.toml is the single source of truth for node, aube, task, gh and yq.
       - name: Install toolchain
         uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
 
-      - name: Install dependencies
-        run: aube install --frozen-lockfile
-
-      - name: Lint
-        run: task lint
-
-      - name: Typecheck
-        run: task typecheck
-
-      - name: Build
-        run: task build
+      - name: Lint, typecheck and build
+        run: task ci
 
       - name: Upload built site
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -57,37 +45,13 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-  publish:
-    runs-on: ubuntu-latest
-    needs: build
-    permissions:
-      packages: write
-      contents: read
-
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Download built site
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: dist
-          path: dist
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
-
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/blit
-          tags: |
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-            type=sha
+      # Exposes ACTIONS_RUNTIME_TOKEN and friends so `--cache-to type=gha` works
+      # from the buildx CLI rather than only inside build-push-action.
+      - name: Expose Actions runtime for the buildx cache
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -97,58 +61,34 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
-        with:
-          context: .
-          file: Dockerfile
-          platforms: linux/amd64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Build container image
+        env:
+          CACHE_FROM: type=gha
+          CACHE_TO: type=gha,mode=max
+        run: >-
+          task docker:build
+          SHA=${{ github.sha }}
+          PUSH=${{ github.event_name != 'pull_request' }}
+          LATEST=${{ github.ref == 'refs/heads/main' }}
 
   update-deployment:
     runs-on: ubuntu-latest
-    needs: publish
+    needs: build
     if: github.ref == 'refs/heads/main'
 
-    env:
-      SHORT_SHA: sha-${{ github.sha }}
-
     steps:
-      - name: Checkout deployment repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          repository: ${{ env.ACCOUNT }}/${{ env.DEPLOYMENT_REPO }}
-          ref: ${{ env.DEPLOYMENT_BRANCH }}
-          token: ${{ secrets.DEPLOYMENT_PAT }}
-          path: ${{ env.DEPLOYMENT_REPO }}
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Update service tag and httpPort in deployment config
+      - name: Install toolchain
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+
+      - name: Update deployment config
+        env:
+          GH_TOKEN: ${{ secrets.DEPLOYMENT_PAT }}
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: |
-          SHORT_SHA_TRIMMED="${{ env.SHORT_SHA }}"
-          SHORT_SHA_TRIMMED=${SHORT_SHA_TRIMMED:0:11}
-
-          yq eval \
-            '(.config."jaritanet:services"."${{ env.PROJECT_NAME }}".args.image.tag) = "'$SHORT_SHA_TRIMMED'"' \
-            -i ${{ env.DEPLOYMENT_REPO }}/${{ env.DEPLOYMENT_CONFIG_PATH }}
-
-          yq eval \
-            '(.config."jaritanet:services"."${{ env.PROJECT_NAME }}".args.httpPort) = 3000' \
-            -i ${{ env.DEPLOYMENT_REPO }}/${{ env.DEPLOYMENT_CONFIG_PATH }}
-
-      - name: Commit and push deployment update
-        run: |
-          cd ${{ env.DEPLOYMENT_REPO }}
-
-          SHORT_SHA_TRIMMED="${{ env.SHORT_SHA }}"
-          SHORT_SHA_TRIMMED=${SHORT_SHA_TRIMMED:0:11}
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add ${{ env.DEPLOYMENT_CONFIG_PATH }}
-          git commit -m "🚀 Update ${{ env.PROJECT_NAME }} service to $SHORT_SHA_TRIMMED"
-          git push
+          gh auth setup-git
+          task deploy:update SHA=${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .DS_Store
 .cache
 .env
+.deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ a commit to watch it.
   selects `--frozen-lockfile`, `CACHE_FROM`/`CACHE_TO` select GitHub's buildx cache,
   `GH_TOKEN` authorises the deployment push. Unset, each falls back to the local
   equivalent, so the command doesn't change shape between the two.
+- **OCI labels moved to the Dockerfile**, which is where the constant ones belong;
+  `revision`, `created` and `version` still come from the build. Output matches what
+  `docker/metadata-action` emitted, except `version`, which is now the image's own tag
+  rather than always `latest`. `image.licenses` is pinned empty so the image stops
+  inheriting the base image's MIT claim.
 - **The image tag is defined once**, in the Taskfile, and derived from `SHA`. Both the
   build and the deployment job read the same definition instead of the workflow
   trimming `sha-$GITHUB_SHA` to 11 characters by hand.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+### CI moved into the Taskfile
+
+GitHub Actions now supplies only an environment — checkout, mise toolchain, registry
+credentials, build cache — and every step of substance is a Taskfile target. The
+pipeline is reproducible on a laptop, and a CI failure is debuggable without pushing
+a commit to watch it.
+
+- `task ci` (checks then build), `task docker:build` and `task deploy:update` replace
+  the inline `run:` steps, `docker/metadata-action`, `docker/build-push-action` and
+  the yq-and-git shell block that rewrote the IaC repo's Pulumi config.
+- **Runner-only capabilities arrive as environment, not workflow logic**: `CI`
+  selects `--frozen-lockfile`, `CACHE_FROM`/`CACHE_TO` select GitHub's buildx cache,
+  `GH_TOKEN` authorises the deployment push. Unset, each falls back to the local
+  equivalent, so the command doesn't change shape between the two.
+- **The image tag is defined once**, in the Taskfile, and derived from `SHA`. Both the
+  build and the deployment job read the same definition instead of the workflow
+  trimming `sha-$GITHUB_SHA` to 11 characters by hand.
+- **The build and publish jobs merged.** They existed to hand `dist/` over as an
+  artifact; `docker:build` depends on `build`, so the round trip was pure latency. The
+  artifact upload stays, for downloading a PR's output.
+- Dropped `setup-qemu-action` — the only platform built is `linux/amd64` and the
+  runner is already amd64.
+- `gh` and `yq` are pinned in `mise.toml` alongside node, aube and task.
+- `install` and `css` are `run: once`, so the now-parallel checks can't race each
+  other into `node_modules`.
+
 ### Rewritten as a static generator — no framework, no bundler, no client JS
 
 The site is two pages, six translated strings and a markdown CV, and its only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 task dev          # Rebuild on change, serve on :3000
 task build        # generate + css + static into dist/
 task generate     # Render the 72 pages only
+task check        # lint + format:check + typecheck, in parallel
+task ci           # What CI runs: check, then build
+task docker:build # Build the container image (PUSH/LATEST to publish)
 task i18n:sync    # Propagate source-locale keys to every catalogue
 task clean        # Drop dist/ and Task's checksum cache
 task lint         # oxlint  (task lint -- --fix to autofix)
@@ -61,3 +64,8 @@ Key decisions:
 - `/style.css` carries a content digest as a query string. nano-web serves CSS
   `immutable, max-age=1y`, so a stable URL would strand visitors on old styles.
 - Adding a page means a template plus an entry in `src/i18n/routes.ts`.
+- GitHub Actions is an environment, not a pipeline: it checks out, installs mise,
+  supplies credentials and a cache, then calls Taskfile targets. Anything a runner has
+  and a laptop doesn't must arrive as an environment variable the Taskfile reads
+  (`CI`, `CACHE_FROM`/`CACHE_TO`, `GH_TOKEN`) rather than as logic in the workflow. If
+  a step can't be run locally, it's in the wrong file.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 # syntax=docker/dockerfile:1.2
 FROM ghcr.io/radiosilence/nano-web:latest
+
+# The constant half of the OCI labels; the Taskfile adds revision, created and
+# version. image.source is the load-bearing one — it links the ghcr package back to
+# the repository.
+LABEL org.opencontainers.image.source="https://github.com/radiosilence/blit" \
+  org.opencontainers.image.url="https://github.com/radiosilence/blit" \
+  org.opencontainers.image.title="blit" \
+  org.opencontainers.image.description="blit.cc personal site" \
+  org.opencontainers.image.vendor="James Cleveland" \
+  org.opencontainers.image.licenses=""
+
 COPY dist /public
 ENV PORT=3000
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -64,15 +64,18 @@ The source locale is served at `/` and `/cv`; every other locale is prefixed
 
 ## Commands
 
-| Command          | Notes                                              |
-| ---------------- | -------------------------------------------------- |
-| `task dev`       | Rebuild on change, serve on :3000                  |
-| `task build`     | Generate, compile CSS and copy assets into `dist/` |
-| `task generate`  | Render the 72 pages only                           |
-| `task i18n:sync` | Sync locale catalogues against the source          |
-| `task clean`     | Drop `dist/` and Task's checksum cache             |
+| Command             | Notes                                              |
+| ------------------- | -------------------------------------------------- |
+| `task dev`          | Rebuild on change, serve on :3000                  |
+| `task build`        | Generate, compile CSS and copy assets into `dist/` |
+| `task generate`     | Render the 72 pages only                           |
+| `task check`        | Lint, formatting and types                         |
+| `task ci`           | Exactly what CI runs — `check`, then `build`       |
+| `task docker:build` | Build the container image                          |
+| `task i18n:sync`    | Sync locale catalogues against the source          |
+| `task clean`        | Drop `dist/` and Task's checksum cache             |
 
-`task --list` shows the rest (lint, format, typecheck).
+`task --list` shows the rest.
 
 ## Adding things
 
@@ -82,6 +85,21 @@ then run `task i18n:sync`. A **page**: add a template and an entry in
 
 ## Deployment
 
-Docker image → microk8s → CloudFlare Tunnel, via Pulumi in a separate IaC repo. CI
-builds `dist/` on the runner and the publish job layers it onto
-[nano-web](https://github.com/radiosilence/nano-web).
+Docker image → microk8s → CloudFlare Tunnel, via Pulumi in a separate IaC repo.
+`dist/` is layered onto [nano-web](https://github.com/radiosilence/nano-web) and the
+image tag is written into the IaC repo's Pulumi config, which Pulumi then rolls out.
+
+GitHub Actions only supplies the environment — a checkout, the mise toolchain,
+registry credentials and a build cache. Each step is a Taskfile target, so the same
+pipeline runs on a laptop:
+
+```bash
+task ci                                # what the build job runs
+task docker:build                      # what it publishes, minus the push
+task deploy:update SHA=$(git rev-parse HEAD)   # what points prod at it
+```
+
+Anything a runner has and a laptop doesn't arrives as environment rather than as
+workflow logic: `CI` selects `--frozen-lockfile`, `CACHE_FROM`/`CACHE_TO` select
+GitHub's buildx cache over the local one, `GH_TOKEN` authorises the push to the IaC
+repo. Unset, each falls back to the local equivalent.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,13 @@ version: "3"
 vars:
   DIST: dist
   BIN: ./node_modules/.bin
+  IMAGE: ghcr.io/radiosilence/blit
+  PLATFORMS: linux/amd64
+  # CI passes the commit explicitly; on a pull_request the checked-out HEAD is a
+  # merge commit that nothing downstream knows about.
+  SHA:
+    sh: git rev-parse HEAD
+  TAG: sha-{{trunc 7 .SHA}}
 
 tasks:
   default:
@@ -11,6 +18,7 @@ tasks:
 
   install:
     internal: true
+    run: once
     # Both guards are needed: sources catch a changed manifest, status catches a
     # deleted node_modules (which no fingerprint would notice).
     sources:
@@ -18,7 +26,7 @@ tasks:
       - aube-lock.yaml
     status:
       - test -d node_modules
-    cmd: aube install
+    cmd: aube install {{if .CI}}--frozen-lockfile{{end}}
 
   build:
     desc: Generate the whole site into dist/
@@ -42,6 +50,7 @@ tasks:
   css:
     desc: Compile Tailwind
     deps: [install]
+    run: once
     sources:
       - src/styles/**/*.css
       - src/templates/**/*.html
@@ -99,3 +108,53 @@ tasks:
   i18n:sync:
     desc: Propagate source-locale keys to every catalogue
     cmd: node scripts/sync-locales.ts
+
+  check:
+    desc: Lint, formatting and types
+    deps: [lint, format:check, typecheck]
+
+  ci:
+    desc: Everything CI verifies — checks, then a full build
+    cmds:
+      - task: check
+      - task: build
+
+  # Cache flags come from the environment so the same command runs locally (buildx's
+  # own cache) and on a runner (GitHub's). PUSH and LATEST are compared as strings
+  # because GitHub expressions render booleans as "true"/"false".
+  docker:build:
+    desc: Build the container image — PUSH=true to push, LATEST=true to also tag latest
+    deps: [build]
+    cmd: >-
+      docker buildx build .
+      --platform {{.PLATFORMS}}
+      --tag {{.IMAGE}}:{{.TAG}}
+      {{if eq .LATEST "true"}}--tag {{.IMAGE}}:latest{{end}}
+      {{if .CACHE_FROM}}--cache-from {{.CACHE_FROM}}{{end}}
+      {{if .CACHE_TO}}--cache-to {{.CACHE_TO}}{{end}}
+      {{if eq .PUSH "true"}}--push{{else}}--load{{end}}
+
+  # Pushes to another repo, so it needs a git credential helper: `gh auth setup-git`
+  # locally, GH_TOKEN plus the same command on a runner.
+  deploy:update:
+    desc: Point the jaritanet deployment at a container tag
+    vars:
+      DEPLOY_REPO: radiosilence/jaritanet
+      DEPLOY_DIR: .deploy
+      DEPLOY_CONFIG: packages/infra/Pulumi.main.yaml
+      SERVICE: blit
+      HTTP_PORT: 3000
+    cmds:
+      - rm -rf {{.DEPLOY_DIR}}
+      - gh repo clone {{.DEPLOY_REPO}} {{.DEPLOY_DIR}} -- --depth 1
+      - >-
+        yq -i '.config."jaritanet:services"."{{.SERVICE}}".args |=
+        (.image.tag = "{{.TAG}}" | .httpPort = {{.HTTP_PORT}})'
+        {{.DEPLOY_DIR}}/{{.DEPLOY_CONFIG}}
+      - |
+        if git -C {{.DEPLOY_DIR}} diff --quiet; then
+          echo "{{.SERVICE}} is already on {{.TAG}}"
+        else
+          git -C {{.DEPLOY_DIR}} commit -am "🚀 Update {{.SERVICE}} to {{.TAG}}"
+          git -C {{.DEPLOY_DIR}} push
+        fi

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,6 +10,8 @@ vars:
   SHA:
     sh: git rev-parse HEAD
   TAG: sha-{{trunc 7 .SHA}}
+  BUILT_AT:
+    sh: date -u +%Y-%m-%dT%H:%M:%SZ
 
 tasks:
   default:
@@ -130,6 +132,9 @@ tasks:
       --platform {{.PLATFORMS}}
       --tag {{.IMAGE}}:{{.TAG}}
       {{if eq .LATEST "true"}}--tag {{.IMAGE}}:latest{{end}}
+      --label org.opencontainers.image.revision={{.SHA}}
+      --label org.opencontainers.image.created={{.BUILT_AT}}
+      --label org.opencontainers.image.version={{.TAG}}
       {{if .CACHE_FROM}}--cache-from {{.CACHE_FROM}}{{end}}
       {{if .CACHE_TO}}--cache-to {{.CACHE_TO}}{{end}}
       {{if eq .PUSH "true"}}--push{{else}}--load{{end}}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,13 +5,6 @@ vars:
   BIN: ./node_modules/.bin
   IMAGE: ghcr.io/radiosilence/blit
   PLATFORMS: linux/amd64
-  # CI passes the commit explicitly; on a pull_request the checked-out HEAD is a
-  # merge commit that nothing downstream knows about.
-  SHA:
-    sh: git rev-parse HEAD
-  TAG: sha-{{trunc 7 .SHA}}
-  BUILT_AT:
-    sh: date -u +%Y-%m-%dT%H:%M:%SZ
 
 tasks:
   default:
@@ -121,12 +114,24 @@ tasks:
       - task: check
       - task: build
 
-  # Cache flags come from the environment so the same command runs locally (buildx's
-  # own cache) and on a runner (GitHub's). PUSH and LATEST are compared as strings
+  # Cache flags are read from the environment so a caller can point buildx at a shared
+  # cache; unset, it uses the local one. PUSH and LATEST are compared as strings
   # because GitHub expressions render booleans as "true"/"false".
   docker:build:
     desc: Build the container image — PUSH=true to push, LATEST=true to also tag latest
     deps: [build]
+    # SHA is derived here rather than globally: Task evaluates global `sh:` vars on
+    # every invocation, so `task lint` and the dev watch loop would fork git too. The
+    # self-reference is load-bearing — a plain task-level var outranks a CLI-passed
+    # one, which would silently discard the SHA= the caller supplied. CI supplies it
+    # because on a pull_request the checked-out HEAD is a merge commit that nothing
+    # downstream knows about.
+    vars:
+      SHA:
+        sh: "{{if .SHA}}echo {{.SHA}}{{else}}git rev-parse HEAD{{end}}"
+      TAG: sha-{{trunc 7 .SHA}}
+      BUILT_AT:
+        sh: date -u +%Y-%m-%dT%H:%M:%SZ
     cmd: >-
       docker buildx build .
       --platform {{.PLATFORMS}}
@@ -145,13 +150,26 @@ tasks:
     desc: Point the jaritanet deployment at a container tag
     vars:
       DEPLOY_REPO: radiosilence/jaritanet
+      DEPLOY_BRANCH: main
       DEPLOY_DIR: .deploy
       DEPLOY_CONFIG: packages/infra/Pulumi.main.yaml
       SERVICE: blit
       HTTP_PORT: 3000
+      # See docker:build for why SHA is shaped this way.
+      SHA:
+        sh: "{{if .SHA}}echo {{.SHA}}{{else}}git rev-parse HEAD{{end}}"
+      TAG: sha-{{trunc 7 .SHA}}
     cmds:
       - rm -rf {{.DEPLOY_DIR}}
-      - gh repo clone {{.DEPLOY_REPO}} {{.DEPLOY_DIR}} -- --depth 1
+      # --branch is explicit: cloning whatever the default branch happens to be would
+      # commit the tag bump somewhere nothing deploys from.
+      - gh repo clone {{.DEPLOY_REPO}} {{.DEPLOY_DIR}} -- --depth 1 --branch {{.DEPLOY_BRANCH}}
+      # yq's |= creates a missing path rather than failing on it, so a renamed service
+      # or moved config would write a new node and push it as if it were a deploy.
+      # -e exits non-zero on null, turning that into a failure before anything is written.
+      - >-
+        yq -e '.config."jaritanet:services"."{{.SERVICE}}".args.image.tag'
+        {{.DEPLOY_DIR}}/{{.DEPLOY_CONFIG}} > /dev/null
       - >-
         yq -i '.config."jaritanet:services"."{{.SERVICE}}".args |=
         (.image.tag = "{{.TAG}}" | .httpPort = {{.HTTP_PORT}})'

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,6 @@
 node = "24"
 aube = "1"
 task = "3"
+# Used by the deploy task; pinned here so CI gets them from the same place as a laptop.
+gh = "2"
+yq = "4"


### PR DESCRIPTION
GitHub Actions supplies a checkout, the mise toolchain and registry credentials.
Everything else is a Taskfile target, so the pipeline runs on a laptop:

```bash
task ci                                       # the build job
task docker:build                             # what it publishes, minus the push
task deploy:update SHA=$(git rev-parse HEAD)  # what points prod at it
```

## Load-bearing decisions

**Runner-only capabilities arrive as environment, not workflow logic.** Task exposes
OS env in its templates, so `CI` selects `--frozen-lockfile` and `GH_TOKEN` authorises
the push to `jaritanet`. Unset, each falls back to the local equivalent — the command
doesn't change shape between the two.

**The image tag is defined once**, in the Taskfile, derived from `SHA`. Both jobs read
that definition instead of the deployment job re-deriving it by trimming
`sha-$GITHUB_SHA` to 11 characters. `SHA` is passed explicitly from `github.sha`
because on a `pull_request` the checked-out HEAD is a merge commit.

**`SHA`/`TAG`/`BUILT_AT` are task-scoped, and self-referencing.** Task evaluates global
`sh:` vars on *every* invocation, so declaring them globally made `task lint`, `task
--list` and the dev watch loop each fork `git` and `date`. Scoping them to the two
tasks that consume them fixes that — but a plain task-level `vars:` entry *outranks* a
CLI-passed one, which would have silently discarded the `SHA=` CI passes and tagged PR
builds with the merge commit. Hence `sh: '{{if .SHA}}echo {{.SHA}}{{else}}git rev-parse
HEAD{{end}}'`, which takes the caller's value when there is one and shells out only
when there isn't.

**`docker/metadata-action` and `docker/build-push-action` are gone**, replaced by
`docker buildx build`. The OCI labels that action was emitting are carried over by
hand: the constant ones live in the Dockerfile, `revision`, `created` and `version`
come from the build. `image.source` is the load-bearing one — it's what links the ghcr
package to this repo.

**No build cache.** The image is `FROM` + `LABEL` + `COPY dist /public`, and `dist/`
changes on every build by definition (the CSS is content-digested), so there is nothing
for `type=gha` to hit — a run imported the manifest and cached zero steps. Dropping it
removes `ghaction-github-runtime` too, which existed solely to export
`ACTIONS_RUNTIME_TOKEN` into every subsequent step for that cache's benefit. The
`CACHE_FROM`/`CACHE_TO` conditionals stay in the Taskfile: they cost nothing and mean
turning it back on is one `env:` block if the Dockerfile grows a build stage.

**The deploy write is guarded.** `yq`'s `|=` creates a missing path rather than failing
on it, so a renamed service or moved config would have written a brand-new node,
committed it and pushed — prod stranded on the old tag behind a green job. A `yq -e`
assertion on the path runs first. The clone also pins `--branch main` rather than
taking whatever `jaritanet`'s default branch happens to be.

**The deploy job is serialised.** Two merges to main in close succession both cloned,
edited and pushed; the loser took a non-fast-forward rejection it couldn't recover from
inside a fresh shallow clone. A superseded run is cancelled rather than queued — it
would only push a tag the newer run is about to replace.

**The build and publish jobs merged.** They only existed to hand `dist/` between
themselves as an artifact, and `docker:build` depends on `build`. The artifact upload
stays, for downloading a PR's output.

`setup-qemu-action` dropped: the only platform built is `linux/amd64` and the runner
is already amd64.

`install` and `css` became `run: once` — `task check` now runs lint, format and
typecheck in parallel, and all three depend on `install`.

## Verifying

Against the currently-published `ghcr.io/radiosilence/blit:latest`, the labels this
produces are identical bar three: `revision` and `created` naturally differ, and
`version` is now the image's own tag rather than always `latest`. `licenses` is pinned
empty to match — otherwise it inherits `MIT` from the nano-web base, a claim this repo
(which has no LICENSE file) doesn't make.

- `task ci` and `task docker:build` both pass locally; the built image was inspected
  for the label comparison above.
- Var precedence was checked against a minimal Taskfile: a plain task-level `vars:`
  entry does override `task foo SHA=…`, and the self-referencing form does not. Fork
  counts confirmed with a shim on `PATH` — `--list`, `lint` and `check` now fork
  neither `git` nor `date`; `docker:build` forks `date` once, and `git` only when no
  `SHA=` is passed.
- The `yq -e` guard was run against a copy of the real `Pulumi.main.yaml` and a
  deliberately drifted one: exit 0 and a one-line `tag:` diff on the former, exit 1 on
  the latter — where the unguarded write instead invents a second `blit:` node.
- `--dry` output checked for all four call shapes (local, PR, main, deploy) — tags and
  `--push`/`--load` render as intended, and CLI-passed `SHA=` reaches `TAG` in both
  tasks.

Not exercised by this PR, since both are main-only: the ghcr push and `deploy:update`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFseKeQBn4jEUrrKhyki4p
