### PR TITLE
refactor: drop the dist prune, wipe on export instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,9 @@ no JavaScript at all, and no `<script>` tag on any page.
 - **`/style.css` is fingerprinted** with a content digest. nano-web serves CSS
   `immutable, max-age=31536000`, so a stable URL left returning visitors on old styles
   after a deploy — a cache-busting regression against the old Vite build.
-- **`generate` prunes orphaned pages.** It only ever wrote files, so a removed locale
-  kept its directory in `dist/` and carried on being served locally.
+- **A removed locale no longer lingers in `dist/`.** The build container starts
+  without a `dist/`, so nothing stale can survive it; on the host, `export --wipe`
+  does the same job, since export merges by default.
 - **`static` is no longer fingerprinted.** Its output is a directory rather than one
   named file, so a partially-deleted `dist/` could not be detected and fonts and icons
   silently 404'd.
@@ -108,8 +109,9 @@ no JavaScript at all, and no `<script>` tag on any page.
 - **Cloudflare/Wrangler removed.** `wrangler.jsonc` and `@cloudflare/vite-plugin` were
   a second, unused deploy target — the live path is Docker → ghcr → microk8s → Pulumi.
 - Build output moved from `dist/client/` to `dist/`; Dockerfile and CI updated.
-- CI installs node, aube and dagger from `mise.toml` via `jdx/mise-action`, replacing
-  `endevco/aube-action`, so the runner and local dev share one toolchain definition.
+- CI installs nothing but Dagger, via `dagger/dagger-for-github`; node and aube are
+  provisioned inside the build container from `mise.toml`, replacing
+  `endevco/aube-action`.
 
 ### Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 dagger call serve up --ports=3000:3000        # Run the real image on :3000
-dagger call build export --path=dist          # Write the site to dist/
+dagger call build export --path=dist --wipe   # Write the site to dist/
 dagger call check                             # lint + typecheck + format check
 dagger call format export --path=.            # Apply formatting
 dagger call sync-locales export --path=src    # Propagate source-locale keys
@@ -65,8 +65,10 @@ Key decisions:
 - The deployment push is a `git` invocation in a container — Dagger's git API is
   read-only. It is the only step with an effect the engine can neither model nor
   cache, which is why it guards on `git diff --quiet` rather than assuming a change.
-- `generate` prunes orphaned `index.html` files and empty directories. Without it a
-  removed locale keeps its directory in `dist/` and carries on being served.
+- `dist/` does not exist in the build container until the build creates it, so there
+  are never stale pages to prune. Staleness now only exists on the host, which is why
+  `build export` passes `--wipe`: export merges by default and would otherwise leave a
+  removed locale's directory behind.
 - `static` is deliberately unfingerprinted: its output is a directory rather than one
   named file, so a partially-deleted `dist/` can't be detected. Copying is cheap.
 - `/style.css` carries a content digest as a query string. nano-web serves CSS

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ since the TypeScript server resolves types from the local tree.
 ```bash
 dagger call serve up --ports=3000:3000        # the real image, on :3000
 dagger call check                             # lint + typecheck + format check
-dagger call build export --path=dist          # write the site to dist/
+dagger call build export --path=dist --wipe   # write the site to dist/
 dagger call format export --path=.            # apply formatting
 dagger call sync-locales export --path=src    # sync catalogues, then format
 ```

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { glob, mkdir, readdir, readFile, rm, rmdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -31,7 +31,7 @@ const [catalogs, cv] = await Promise.all([
   read("src/content/cv.md").then((source) => markdown.render(source)),
 ]);
 
-const written = await Promise.all(
+await Promise.all(
   locales.flatMap((locale) =>
     pages.map(async (page) => {
       const view = {
@@ -56,32 +56,8 @@ const written = await Promise.all(
       const file = join(dist, view.path, "index.html");
       await mkdir(dirname(file), { recursive: true });
       await writeFile(file, html);
-      return file;
     }),
   ),
 );
-
-/*
- * Drop pages from earlier builds. Without this a removed locale keeps its
- * directory in dist/ and carries on being served. Only index.html files are
- * touched, which is exactly the set this script owns.
- */
-const current = new Set(written);
-const stale: string[] = [];
-for await (const page of glob("*/**/index.html", { cwd: dist })) {
-  if (!current.has(join(dist, page))) stale.push(join(dist, page));
-}
-await Promise.all(stale.map((page) => rm(page)));
-
-// Depth-first: children have to be gone before a directory can be judged empty.
-const prune = async (dir: string) => {
-  const entries = await readdir(dir, { withFileTypes: true });
-  await Promise.all(
-    entries.filter((entry) => entry.isDirectory()).map((entry) => prune(join(dir, entry.name))),
-  );
-  if (dir !== dist && (await readdir(dir)).length === 0) await rmdir(dir);
-};
-
-await prune(dist);
 
 console.log(`Generated ${locales.length * pages.length} pages in ${dist}`);


### PR DESCRIPTION
`scripts/generate.ts` pruned orphaned `index.html` files and empty directories on every run. That existed because Task built into a **persistent** `dist/`, so deleting a locale left its directory behind and nano-web carried on serving it.

The build container has no `dist/` until the build creates it — verified: `ls /src` in `deps` shows `node_modules`, `scripts`, `src` and no `dist`. So there has never been anything stale for the prune to find since the Taskfile went. It was dead code.

## The hazard moved rather than vanished

`Directory.export` **merges by default** (`Wipe: false`), so exporting onto an existing local `dist/` leaves a removed locale on the host — and the prune could never have fixed that, because it ran inside the container where nothing was stale.

So `build export` now passes `--wipe`, and the docs say why.

## Verification

Planted a `zz-OLD/index.html` in the target directory:

```
after plain export, stale locale present? YES
after --wipe export,  stale locale present? no
pages still correct: 72
```

Build output byte-identical to the previous module. `generate.ts` goes from 87 to 63 lines, and drops the `glob`, `readdir`, `rm` and `rmdir` imports it only used for pruning.

## Also

Corrected a changelog line still claiming CI installs node and aube via `jdx/mise-action` — it installs nothing but Dagger now.