### PR TITLE
ci: gate publishing on the ref, and move actions off Node 20

### DIFF
--- a/.github/workflows/publish-web-container.yml
+++ b/.github/workflows/publish-web-container.yml
@@ -28,17 +28,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # mise.toml is the single source of truth for node, aube, task, gh and yq.
       - name: Install toolchain
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
 
       - name: Lint, typecheck and build
         run: task ci
 
       - name: Upload built site
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist
@@ -46,11 +46,14 @@ jobs:
           if-no-files-found: error
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      # Both this and PUSH below key on the ref rather than the event: the trigger list
+      # is what currently makes "not a pull_request" mean main, and a future
+      # workflow_dispatch or added branch would quietly start publishing.
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -63,7 +66,7 @@ jobs:
         run: >-
           task docker:build
           SHA=${{ github.sha }}
-          PUSH=${{ github.event_name != 'pull_request' }}
+          PUSH=${{ github.ref == 'refs/heads/main' }}
           LATEST=${{ github.ref == 'refs/heads/main' }}
 
   update-deployment:
@@ -80,10 +83,10 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install toolchain
-        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
 
       - name: Update deployment config
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,38 @@
 
 ### CI moved into the Taskfile
 
-GitHub Actions now supplies only an environment — checkout, mise toolchain, registry
-credentials, build cache — and every step of substance is a Taskfile target. The
+GitHub Actions now supplies only an environment — checkout, mise toolchain and
+registry credentials — and every step of substance is a Taskfile target. The
 pipeline is reproducible on a laptop, and a CI failure is debuggable without pushing
 a commit to watch it.
 
 - `task ci` (checks then build), `task docker:build` and `task deploy:update` replace
   the inline `run:` steps, `docker/metadata-action`, `docker/build-push-action` and
   the yq-and-git shell block that rewrote the IaC repo's Pulumi config.
-- **Runner-only capabilities arrive as environment, not workflow logic**: `CI`
-  selects `--frozen-lockfile`, `CACHE_FROM`/`CACHE_TO` select GitHub's buildx cache,
-  `GH_TOKEN` authorises the deployment push. Unset, each falls back to the local
-  equivalent, so the command doesn't change shape between the two.
+- **Runner-only capabilities arrive as environment, not workflow logic**: `CI` selects
+  `--frozen-lockfile`, `GH_TOKEN` authorises the deployment push, and
+  `CACHE_FROM`/`CACHE_TO` point buildx at a shared cache. Unset, each falls back to the
+  local equivalent, so the command doesn't change shape between the two.
+- **No build cache is configured.** The image is a `FROM`, a `LABEL` and a `COPY` of
+  `dist/`, whose content changes every build, so `type=gha` imported a manifest and
+  cached zero steps. Dropping it also removes the action that existed only to export
+  `ACTIONS_RUNTIME_TOKEN` for its benefit. The Taskfile keeps the conditionals.
+- **Publishing is gated on the ref, not the event type.** `PUSH` previously keyed on
+  "not a pull_request", which meant main only because the trigger list happened to
+  contain nothing else; adding a `workflow_dispatch` or a second push branch would have
+  started publishing from it silently.
+- **The deploy write asserts before it writes.** `yq`'s `|=` creates a missing path
+  rather than failing, so a renamed service or moved config would have committed an
+  invented node and left prod on the old tag behind a green job. The clone also pins
+  `--branch main` instead of following whatever the IaC repo's default branch is.
+- **The deploy job is serialised.** Two merges in close succession both cloned, edited
+  and pushed; the loser hit a non-fast-forward it couldn't recover from inside a fresh
+  shallow clone.
+- **`SHA`/`TAG`/`BUILT_AT` are scoped to the tasks that use them.** Task evaluates
+  global `sh:` vars on every invocation, so declaring them globally made `task lint`
+  and the watch loop fork `git` and `date`. They resolve to a caller-supplied value
+  first — a plain task-level var outranks one passed on the command line, which would
+  have silently discarded the commit CI passes.
 - **OCI labels moved to the Dockerfile**, which is where the constant ones belong;
   `revision`, `created` and `version` still come from the build. Output matches what
   `docker/metadata-action` emitted, except `version`, which is now the image's own tag
@@ -30,6 +50,8 @@ a commit to watch it.
 - Dropped `setup-qemu-action` — the only platform built is `linux/amd64` and the
   runner is already amd64.
 - `gh` and `yq` are pinned in `mise.toml` alongside node, aube and task.
+- Actions bumped to releases that declare the `node24` runtime; the previous pins all
+  targeted Node 20 and were being forced onto 24 by the runner.
 - `install` and `css` are `run: once`, so the now-parallel checks can't race each
   other into `node_modules`.
 


### PR DESCRIPTION
Follow-up to #16, which merged while these two commits were in flight.

## Node 20 actions

Every action in the workflow targeted Node 20 and the runner was already forcing
them onto 24, per [the deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).
Bumped to releases that declare `node24`:

| action | was | now |
|---|---|---|
| `actions/checkout` | v4 | v7.0.1 |
| `actions/upload-artifact` | v4.6.2 | v7.0.1 |
| `docker/login-action` | v3 | v4.5.1 |
| `docker/setup-buildx-action` | v3 | v4.2.0 |
| `jdx/mise-action` | v2 | v4.2.3 |

Three of those cross multiple majors, so the inputs this workflow actually passes were
checked against each pinned `action.yml` rather than assumed: `name`/`path`/
`retention-days`/`if-no-files-found` on upload-artifact and `registry`/`username`/
`password` on login-action all still exist, and nothing became required-without-default
that isn't already supplied. `using: node24` was read from each pinned SHA, not from
the tag.

## Publishing gated on the ref

`PUSH` keyed on `github.event_name != 'pull_request'`. That resolved to "main" only
because `on:` happens to contain nothing but `push: branches: [main]` and
`pull_request` — the guarantee lived in the trigger list rather than at the point of
the push. Adding a `workflow_dispatch`, a tag trigger or a second push branch would
have quietly started publishing `sha-` tags from it. `LATEST` was already ref-keyed, so
`:latest` was never at risk; this brings `PUSH` and the registry login into line with
it.

No behaviour change on the two events that exist today.

## Changelog

The Unreleased entry from #16 described that PR's *first* commit: it credited
`CACHE_FROM`/`CACHE_TO` with selecting a GitHub cache that the same PR later removed,
and the review fixes (the `yq -e` guard, the `--branch main` pin, the concurrency
group, the task-scoped vars) never got written down. Corrected here.

## Verifying

- `task check` passes; `--dry` still renders `--load` for `PUSH=false` and `--push` for
  `PUSH=true`.
- The gating is unchanged for both live events — a PR has `github.ref` of
  `refs/pull/N/merge`, so `PUSH` is false exactly as before, and pushes to main are
  `refs/heads/main`.
- #16's merge exercised the deploy path for real for the first time: the `yq -e` guard
  passed against the live `Pulumi.main.yaml`, the pinned clone worked, and jaritanet
  took `🚀 Update blit to sha-ff965b1`. `:latest` now points at a main commit again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFseKeQBn4jEUrrKhyki4p
