### PR TITLE
refactor: pages declare their layout, and the Proxy survives the boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Templates use layouts, and the Proxy now survives the boundary
+
+A page declares the frame it slots into (`<% layout("./base") %>`) instead of `base`
+including a page named by the view. The frame no longer needs to be told what it
+wraps, and `content` is gone from the view.
+
+- **The strict-view Proxy is applied to `eta.render` rather than the outermost call.**
+  Eta crosses into a layout — and into `include()` — by spreading the view into a
+  fresh object, and spreading a Proxy yields a plain one. Top-level keys were
+  therefore unguarded past the first boundary: a mistyped `it.cv` in `cv.html` built
+  green and shipped the string `undefined`. Both paths route through `this.render`, so
+  re-wrapping there closes it for layouts and includes alike.
+- Output is byte-identical across all 72 pages.
+
 ### CI moved into the Taskfile
 
 GitHub Actions now supplies only an environment — checkout, mise toolchain and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,12 @@ Key decisions:
 - `scripts/render.ts` wraps the view in a Proxy that throws on unknown keys, so a
   template typo fails the build with the path and the keys that do exist. Generation
   time is the only runtime here, so this is the type check.
+- The wrap is applied to `eta.render` itself, not just the outermost call. Eta crosses
+  into a layout by spreading the view to add `body`, and spreading a Proxy yields a
+  plain object — so a top-level key would stop being guarded past the first boundary.
+- Pages declare their frame (`<% layout("./base") %>`) rather than the frame including
+  the page. The rendered child arrives as `it.body`. Eta also has named blocks if a
+  page ever needs to fill more than one slot.
 - PO keys are short identifiers (`tagline`), not English sentences. Missing keys fall
   back to `en-GB`.
 - Pages are written as directory indexes (`dist/cv/index.html`) because nano-web

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -41,7 +41,6 @@ const written = await Promise.all(
         cv,
         styleHref,
         path: url(locale, page.slug),
-        content: page.template,
         urls: Object.fromEntries(pages.map(({ slug }) => [slug || "home", url(locale, slug)])),
         localeLinks: locales.map((code) => ({
           code,
@@ -51,7 +50,7 @@ const written = await Promise.all(
         })),
       };
 
-      const html = render("base", view);
+      const html = render(page.template, view);
 
       const file = join(dist, view.path, "index.html");
       await mkdir(dirname(file), { recursive: true });

--- a/scripts/render.ts
+++ b/scripts/render.ts
@@ -40,6 +40,16 @@ function strict<T>(value: T, path: string): T {
   }) as T;
 }
 
+/*
+ * Eta reaches a layout by spreading the view into a fresh object to add `body`,
+ * and spreading a Proxy yields a plain one. Both `layout()` and `include()` route
+ * through this.render, so re-wrapping here is what keeps a mistyped key throwing
+ * across the boundary instead of rendering "undefined".
+ */
+const inner = eta.render.bind(eta);
+eta.render = ((template, view, meta) =>
+  inner(template, strict(view, "it"), meta)) as typeof eta.render;
+
 export function render(template: string, view: Record<string, unknown>) {
-  return eta.render(template, strict(view, "it"));
+  return eta.render(template, view);
 }

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -25,7 +25,7 @@
   </head>
 
   <body>
-    <%~ include(it.content, it) %>
+    <%~ it.body %>
 
     <nav class="fixed end-2 bottom-2 text-xs">
       <button

--- a/src/templates/cv.html
+++ b/src/templates/cv.html
@@ -1,3 +1,4 @@
+<% layout("./base") %>
 <div class="mx-4 flex flex-col items-center lg:mx-0">
   <section class="mb-12 max-w-5xl">
     <a href="<%= it.urls.home %>">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,3 +1,4 @@
+<% layout("./base") %>
 <section class="m-12 flex flex-col items-center space-y-4 text-center">
   <img
     src="/logo.png"


### PR DESCRIPTION
`cv.html` and `index.html` now declare the frame they slot into rather than `base.html`
including a page named by the view:

```
base.html   <%~ include(it.content, it) %>   →   <%~ it.body %>
cv.html                                      →   <% layout("./base") %> at the top
generate.ts render("base", view)             →   render(page.template, view)
```

`content` drops out of the view entirely — the frame no longer needs telling what it
wraps.

## The part worth reviewing

Eta reaches a layout by spreading the view into a fresh object to attach `body`.
Spreading a Proxy yields a *plain* object, so the strict view in `render.ts` stopped
guarding top-level keys the moment it crossed a boundary.

That hole is not new — `include()` spreads the same way, so it is on `main` today:

```
$ sed -i 's/it\.cv/it.cvv/' src/templates/cv.html && node scripts/generate.ts
Generated 72 pages          # exit 0
$ grep -o undefined dist/cv/index.html
undefined                   # shipped
```

Nested keys survived (spread reads each value *through* the trap, so `it.t` arrived
already wrapped) which is why this stayed invisible — almost every interpolation in
these templates is nested. `base.html` is the exception: `styleHref`, `path`, `dir`,
`locale` are all top-level.

Both `layout()` and `include()` route through `this.render`, so the fix is to wrap that
rather than only the outermost call. `render` is an instance property on the Eta object,
not a prototype method, so it is replaced in place rather than subclassed.

## Verifying

- **Byte-identical output**: `dist/` diffed against a build of `main`, all 72 pages,
  no differences.
- **The guard now holds across the boundary** — each of these fails the build, naming
  the path, where the first two passed silently before:

  | injected typo | before | after |
  |---|---|---|
  | top-level in the layout (`it.styleHreff`) | rendered `undefined` | build fails |
  | top-level in a child (`it.cvv`) | rendered `undefined` | build fails |
  | nested in a child (`it.t.taglinne`) | build fails | build fails |

- `task ci` passes.

Eta also supports named blocks, so a page can fill more than one slot if that's ever
needed. Not used yet — `body` is the only slot base.html has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFseKeQBn4jEUrrKhyki4p
