### PR TITLE
refactor: no regex — every dynamic value is an element or attribute

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -13,6 +13,9 @@ importers:
       "@tailwindcss/typography":
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
+      "@types/escape-html":
+        specifier: ^1.0.4
+        version: 1.0.4
       "@types/gettext-parser":
         specifier: ^9.0.0
         version: 9.0.0
@@ -22,6 +25,9 @@ importers:
       "@types/node":
         specifier: ^24.10.1
         version: 24.13.3
+      escape-html:
+        specifier: ^1.0.3
+        version: 1.0.3
       gettext-parser:
         specifier: ^9.1.1
         version: 9.1.1
@@ -477,6 +483,12 @@ packages:
     peerDependencies:
       tailwindcss: ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
 
+  "@types/escape-html@1.0.4":
+    resolution:
+      {
+        integrity: sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==,
+      }
+
   "@types/gettext-parser@9.0.0":
     resolution:
       {
@@ -572,6 +584,12 @@ packages:
         integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==,
       }
     engines: { node: ">=20.19.0" }
+
+  escape-html@1.0.3:
+    resolution:
+      {
+        integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
+      }
 
   fill-range@7.1.1:
     resolution:
@@ -1107,6 +1125,8 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
 
+  "@types/escape-html@1.0.4": {}
+
   "@types/gettext-parser@9.0.0":
     dependencies:
       "@types/node": 24.13.3
@@ -1150,6 +1170,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@8.0.0: {}
+
+  escape-html@1.0.3: {}
 
   fill-range@7.1.1:
     dependencies:

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   "devDependencies": {
     "@tailwindcss/cli": "^4.3.0",
     "@tailwindcss/typography": "^0.5.19",
+    "@types/escape-html": "^1.0.4",
     "@types/gettext-parser": "^9.0.0",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^24.10.1",
+    "escape-html": "^1.0.3",
     "gettext-parser": "^9.1.1",
     "lefthook": "^2.1.6",
     "markdown-it": "^14.1.0",

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -42,6 +42,7 @@ const written = await Promise.all(
         cv,
         styleHref,
         path: url(locale, page.slug),
+        canonicalUrl: `https://blit.cc${url(locale, page.slug)}`,
         urls: Object.fromEntries(pages.map(({ slug }) => [slug || "home", url(locale, slug)])),
         localeLinks: locales.map((code) => ({
           code,
@@ -94,8 +95,11 @@ await prune(dist);
 const pageFiles = new Set(written);
 const broken: string[] = [];
 
-for (const file of written) {
-  const html = await readFile(file, "utf8");
+const rendered = await Promise.all(
+  written.map(async (file) => [file, await readFile(file, "utf8")] as const),
+);
+
+for (const [file, html] of rendered) {
   const walkLinks = (node: { childNodes?: unknown[] }) => {
     for (const child of (node.childNodes ?? []) as {
       tagName?: string;

--- a/scripts/i18n.ts
+++ b/scripts/i18n.ts
@@ -19,16 +19,16 @@ import { locales, sourceLocale } from "#/i18n/config.ts";
 const root = fileURLToPath(new URL("..", import.meta.url));
 const messages = new Map<string, string[]>();
 
+const text = (node: DefaultTreeAdapterMap["element"]) =>
+  (node.childNodes ?? [])
+    .map((child) => (child.nodeName === "#text" ? (child as { value: string }).value : ""))
+    .join("")
+    .trim();
+
 const add = (id: string, where: string) => messages.set(id, [...(messages.get(id) ?? []), where]);
 
 for await (const file of glob("src/templates/**/*.html", { cwd: root })) {
   const source = await readFile(new URL(file, new URL(root, "file:")), "utf8");
-  const text = (node: DefaultTreeAdapterMap["element"]) =>
-    (node.childNodes ?? [])
-      .map((child) => (child.nodeName === "#text" ? (child as { value: string }).value : ""))
-      .join("")
-      .trim();
-
   (function walk(node: DefaultTreeAdapterMap["parentNode"]) {
     for (const child of node.childNodes ?? []) {
       if (!("tagName" in child)) continue;
@@ -48,7 +48,7 @@ for await (const file of glob("src/templates/**/*.html", { cwd: root })) {
   })(parse(source, { sourceCodeLocationInfo: true }));
 }
 
-const ids = [...messages.keys()].sort();
+const ids = [...messages.keys()].toSorted();
 if (!ids.length)
   throw new Error("No translatable text found — that is almost certainly a bug here.");
 

--- a/scripts/template.ts
+++ b/scripts/template.ts
@@ -1,35 +1,41 @@
 /**
- * A template is valid HTML. Components are custom elements resolved to a file of
- * the same name, children arrive through `<slot>`, and `{dotted.path}` reads the
- * view. Everything is expanded at build time, so the browser gets plain HTML.
+ * A template is valid HTML, so an HTML parser reads it. Components are custom
+ * elements resolved to a file of the same name, children arrive through `<slot>`,
+ * and every dynamic value is an element or an attribute — there is nothing to
+ * scan for, and no regular expression anywhere in this file.
  *
- * Expressions are paths and nothing else — no calls, no operators, no ternaries.
- * That is what lets `scripts/i18n.ts` and `checkPaths` below read a template
- * statically instead of executing it, and it keeps computation in generate.ts
- * where it can be typed.
+ *   <page-base>…</page-base>        a component; children land in its <slot>
+ *   :href="urls.cv"                 bind an attribute to a path
+ *   :class="option.linkClass"       append to the static class already there
+ *   autofocus?="option.current"     emit a bare attribute when truthy
+ *   <x-text of="locale" />          a path as text
+ *   <x-raw of="cv" />               a path as markup, already HTML
+ *   <x-each of="items" as="item">   repeat the children
+ *   <i18n-t>source text</i18n-t>    translate; the id is the text itself
+ *   <title i18n>…</title>           translate an element's text in place
+ *   i18n-content="source text"      translate into an attribute
  *
- * parse5 gives structure; the output is spliced from the original source rather
- * than serialised from the tree, because serialising rewrites `<!doctype html>`,
- * drops self-closing slashes and reflows whitespace.
+ * A value is a dotted path and nothing else. That is what lets scripts/i18n.ts
+ * read a template statically rather than executing it, and a wrong path fail the
+ * build naming what the view does have.
+ *
+ * Output is spliced into the original source by offset rather than serialised
+ * from the tree: serialising uppercases `<!doctype html>`, drops self-closing
+ * slashes and reflows whitespace.
  */
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import escapeHtml from "escape-html";
 import { type DefaultTreeAdapterMap, parse, parseFragment } from "parse5";
 
 type Node = DefaultTreeAdapterMap["childNode"];
 type Element = DefaultTreeAdapterMap["element"];
 type View = Record<string, unknown>;
+type Edit = { start: number; end: number; text: string };
 
 const dir = fileURLToPath(new URL("../src/templates/", import.meta.url));
-const PATH = /\{([\w.]+)\}/g;
-
-const escape = (value: string) =>
-  value.replace(
-    /[&<>"']/g,
-    (char) =>
-      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[char] as string,
-  );
+const I18N = "i18n-";
 
 class TemplateError extends Error {
   constructor(where: string, message: string) {
@@ -38,7 +44,7 @@ class TemplateError extends Error {
   }
 }
 
-/** Resolves `a.b.c`, refusing anything the view doesn't have — a typo is a build failure. */
+/** Resolves `a.b.c`. A path the view lacks is a build failure, not an empty string. */
 function resolve(path: string, view: View, where: string): unknown {
   let value: unknown = view;
 
@@ -57,18 +63,23 @@ function resolve(path: string, view: View, where: string): unknown {
 }
 
 const isElement = (node: Node): node is Element => "tagName" in node;
-const attr = (node: Element, name: string) => node.attrs.find((a) => a.name === name)?.value;
-
-/** `{path}` inside text or an attribute value. */
-const interpolate = (text: string, view: View, where: string) =>
-  text.replace(PATH, (_, path: string) => escape(String(resolve(path, view, where))));
+const attrOf = (node: Element, name: string) => node.attrs.find((a) => a.name === name)?.value;
+const isDocument = (source: string) => source.trimStart().toLowerCase().startsWith("<!doctype");
 
 export function render(name: string, view: View): string {
   return expand(readFileSync(`${dir}${name}.html`, "utf8"), view, `${name}.html`);
 }
 
 function expand(source: string, view: View, where: string): string {
-  const edits: { start: number; end: number; text: string }[] = [];
+  const edits: Edit[] = [];
+
+  const translate = (id: string) => {
+    const fn = view["__"];
+    if (typeof fn !== "function") throw new TemplateError(where, "no `__` in the view");
+    return String((fn as (id: string) => string)(id));
+  };
+
+  /** The source between a node's tags — what gets re-expanded, or replaced wholesale. */
   const inner = (node: Element) => {
     const at = node.sourceCodeLocation;
     return at?.startTag && at.endTag
@@ -76,149 +87,125 @@ function expand(source: string, view: View, where: string): string {
       : "";
   };
 
-  function walk(node: Node) {
-    if (node.nodeName === "#text") {
-      const at = node.sourceCodeLocation;
-      const text = (node as { value: string }).value;
-      if (at && PATH.test(text)) {
-        edits.push({
-          start: at.startOffset,
-          end: at.endOffset,
-          text: interpolate(text, view, where),
-        });
-      }
-      return;
-    }
+  const replace = (node: Element, text: string) => {
+    const at = node.sourceCodeLocation;
+    if (at) edits.push({ start: at.startOffset, end: at.endOffset, text });
+  };
 
+  const text = (of: string | undefined, tag: string, escape: boolean) => {
+    if (!of) throw new TemplateError(where, `<${tag}> needs \`of\``);
+    const value = String(resolve(of, view, where));
+    return escape ? escapeHtml(value) : value;
+  };
+
+  function walk(node: Node) {
     if (!isElement(node)) return;
     const at = node.sourceCodeLocation;
     if (!at) return;
 
-    const tag = node.tagName;
-
-    // `<i18n-t>text</i18n-t>` — the message id is the source text.
-    if (tag === "i18n-t") {
-      const translate = view["__"] as ((id: string) => string) | undefined;
-      if (!translate) throw new TemplateError(where, "no `__` in the view for <i18n-t>");
-      edits.push({
-        start: at.startOffset,
-        end: at.endOffset,
-        text: escape(translate(inner(node).trim())),
-      });
-      return;
+    switch (node.tagName) {
+      // Already expanded against the caller's view; re-expanding would use this one.
+      case "slot":
+        return replace(node, String(view["slot"] ?? ""));
+      case "i18n-t":
+        return replace(node, escapeHtml(translate(inner(node).trim())));
+      case "x-text":
+        return replace(node, text(attrOf(node, "of"), "x-text", true));
+      case "x-raw":
+        return replace(node, text(attrOf(node, "of"), "x-raw", false));
+      case "x-each": {
+        const of = attrOf(node, "of");
+        const as = attrOf(node, "as");
+        if (!of || !as) throw new TemplateError(where, "<x-each> needs `of` and `as`");
+        const items = resolve(of, view, where);
+        if (!Array.isArray(items)) throw new TemplateError(where, `\`${of}\` is not an array`);
+        const body = inner(node);
+        return replace(node, items.map((i) => expand(body, { ...view, [as]: i }, where)).join(""));
+      }
     }
 
-    // `<x-raw of="cv" />` — markdown that is already HTML.
-    if (tag === "x-raw") {
-      const of = attr(node, "of");
-      if (!of) throw new TemplateError(where, "<x-raw> needs `of`");
-      edits.push({
-        start: at.startOffset,
-        end: at.endOffset,
-        text: String(resolve(of, view, where)),
-      });
-      return;
+    // A hyphenated element is a component; its children fill the component's slot.
+    if (node.tagName.includes("-")) {
+      const props: View = { ...view, slot: expand(inner(node), view, where).trim() };
+      for (const { name, value } of node.attrs) props[name] = value;
+      return replace(node, render(node.tagName, props));
     }
 
-    // `<x-each of="localeLinks" as="option">`
-    if (tag === "x-each") {
-      const of = attr(node, "of");
-      const as = attr(node, "as");
-      if (!of || !as) throw new TemplateError(where, "<x-each> needs `of` and `as`");
-      const items = resolve(of, view, where);
-      if (!Array.isArray(items)) throw new TemplateError(where, `\`${of}\` is not an array`);
-      const body = inner(node);
-      edits.push({
-        start: at.startOffset,
-        end: at.endOffset,
-        text: items.map((item) => expand(body, { ...view, [as]: item }, where)).join(""),
-      });
-      return;
-    }
-
-    // Any other hyphenated element is a component: <page-base>children</page-base>
-    if (tag.includes("-")) {
-      const props: View = { ...view };
-      for (const { name, value } of node.attrs) props[name] = interpolate(value, view, where);
-      props["slot"] = expand(inner(node), view, where).trim();
-      edits.push({ start: at.startOffset, end: at.endOffset, text: render(tag, props) });
-      return;
-    }
-
-    /*
-     * `<title i18n>` and `<meta i18n-content="…">`. Both exist because an element
-     * cannot appear in an attribute value, nor inside RAWTEXT like <title>, so
-     * <i18n-t> has nowhere to go in either position.
-     */
-    const translate = view["__"] as ((id: string) => string) | undefined;
-
-    if (attr(node, "i18n") !== undefined && at.startTag && at.endTag) {
-      if (!translate) throw new TemplateError(where, "no `__` in the view for i18n");
+    // `<title i18n>` exists because an element cannot appear inside RAWTEXT.
+    if (attrOf(node, "i18n") !== undefined && at.startTag && at.endTag) {
       edits.push({
         start: at.startTag.endOffset,
         end: at.endTag.startOffset,
-        text: escape(translate(inner(node).trim())),
+        text: escapeHtml(translate(inner(node).trim())),
       });
-      const location = at.attrs?.["i18n"];
-      if (location) {
-        // Back over the separating whitespace, or the tag keeps a stray gap.
-        let start = location.startOffset;
-        while (start > 0 && /\s/.test(source[start - 1] ?? "")) start--;
-        edits.push({ start, end: location.endOffset, text: "" });
-      }
     }
+
+    const staticClass = attrOf(node, "class");
 
     for (const { name, value } of node.attrs) {
       const location = at.attrs?.[name.toLowerCase()];
       if (!location) continue;
+      const edit = (replacement: string) =>
+        edits.push({ start: location.startOffset, end: location.endOffset, text: replacement });
 
-      if (name === "i18n") continue;
-
-      if (name.startsWith("i18n-")) {
-        if (!translate) throw new TemplateError(where, "no `__` in the view for i18n");
-        edits.push({
-          start: location.startOffset,
-          end: location.endOffset,
-          text: `${name.slice(5)}="${escape(translate(value))}"`,
-        });
+      // The marker is dropped along with the space that separated it from the tag.
+      if (name === "i18n") {
+        let start = location.startOffset;
+        while (start > 0 && " \t\n\r".includes(source[start - 1] ?? "")) start--;
+        edits.push({ start, end: location.endOffset, text: "" });
         continue;
       }
 
-      // `autofocus?="option.current"` emits a bare `autofocus` when truthy.
+      // `i18n-content="…"` exists because an element cannot appear in an attribute.
+      if (name.startsWith(I18N)) {
+        edit(`${name.slice(I18N.length)}="${escapeHtml(translate(value))}"`);
+        continue;
+      }
+
+      // `autofocus?="path"` — for a boolean attribute, presence is the value.
       if (name.endsWith("?")) {
-        const bare = name.slice(0, -1);
-        edits.push({
-          start: location.startOffset,
-          end: location.endOffset,
-          text: resolve(value, view, where) ? bare : "",
-        });
+        edit(resolve(value, view, where) ? name.slice(0, -1) : "");
         continue;
       }
 
-      if (PATH.test(value)) {
-        edits.push({
-          start: location.startOffset,
-          end: location.endOffset,
-          text: `${name}="${interpolate(value, view, where)}"`,
-        });
+      if (!name.startsWith(":")) continue;
+      const bound = escapeHtml(String(resolve(value, view, where)));
+      const bare = name.slice(1);
+
+      /*
+       * `:class` merges into the static class rather than replacing it, so the
+       * literal utilities stay written in the template — which is the only place
+       * Tailwind looks for them.
+       */
+      const classLocation = bare === "class" && staticClass ? at.attrs?.["class"] : undefined;
+      if (!classLocation) {
+        edit(`${bare}="${bound}"`);
+        continue;
       }
+
+      edit("");
+      edits.push({
+        start: classLocation.startOffset,
+        end: classLocation.endOffset,
+        text: `class="${staticClass} ${bound}"`,
+      });
     }
 
     for (const child of node.childNodes ?? []) walk(child);
   }
 
-  // A document keeps <html>/<head>; a fragment would restructure them away.
-  const root = /^\s*<!doctype/i.test(source)
+  // A document keeps <html> and <head>; a fragment would restructure them away.
+  const root = isDocument(source)
     ? parse(source, { sourceCodeLocationInfo: true })
     : parseFragment(source, { sourceCodeLocationInfo: true });
+
   for (const child of root.childNodes) walk(child);
 
   // Descending, so earlier offsets stay valid as later text is replaced.
   let out = source;
-  for (const edit of edits.sort((a, b) => b.start - a.start)) {
+  for (const edit of edits.toSorted((a, b) => b.start - a.start)) {
     out = out.slice(0, edit.start) + edit.text + out.slice(edit.end);
   }
 
-  // `<slot>` is filled last: its content is already expanded and must not be rescanned.
-  return out.replace(/<slot\s*\/?>(?:<\/slot>)?/g, () => String(view["slot"] ?? ""));
+  return out;
 }

--- a/src/templates/cv.html
+++ b/src/templates/cv.html
@@ -1,7 +1,7 @@
 <page-base>
 <div class="mx-4 flex flex-col items-center lg:mx-0">
   <section class="mb-12 max-w-5xl">
-    <a href="{urls.home}">
+    <a :href="urls.home">
       <img src="/logo.png" alt="blit.cc logo" width="128" height="128" class="mt-16 mb-8 lg:mt-32" />
     </a>
     <article class="prose prose-sm"><x-raw of="cv" /></article>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -10,7 +10,7 @@
   <h1><i18n-t>james cleveland</i18n-t></h1>
   <p class="text-sm"><i18n-t>james cleveland : senior full stack engineer</i18n-t></p>
   <p>
-    <a href="{urls.cv}"><i18n-t>cv-2025.01</i18n-t></a>
+    <a :href="urls.cv"><i18n-t>cv-2025.01</i18n-t></a>
     /
     <a href="https://github.com/radiosilence" target="_blank" rel="noopener"
       ><i18n-t>github</i18n-t></a

--- a/src/templates/page-base.html
+++ b/src/templates/page-base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="{locale}" dir="{dir}">
+<html :lang="locale" :dir="dir">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -13,10 +13,10 @@
     <meta name="mobile-web-app-capable" content="yes" />
 
     <meta property="og:title" i18n-content="james cleveland : senior full stack engineer" />
-    <meta property="og:url" content="https://blit.cc{path}" />
+    <meta property="og:url" :content="canonicalUrl" />
     <meta property="og:image" content="https://blit.cc/logo.png" />
 
-    <link rel="stylesheet" href="{styleHref}" />
+    <link rel="stylesheet" :href="styleHref" />
     <link rel="preload" href="/geist-mono.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -34,7 +34,7 @@
         commandfor="locale-dialog"
         class="cursor-pointer p-1 underline"
       >
-        {locale}
+        <x-text of="locale" />
       </button>
     </nav>
 
@@ -64,14 +64,14 @@
         <x-each of="localeLinks" as="option">
         <li>
           <a
-            href="{option.href}"
-            hreflang="{option.code}"
-            lang="{option.code}"
-            aria-current="{option.current}" autofocus?="option.current"
-            class="block px-3 py-2 no-underline hover:bg-brand-mid/20 {option.linkClass}"
+            :href="option.href"
+            :hreflang="option.code"
+            :lang="option.code"
+            :aria-current="option.current" autofocus?="option.current"
+            class="block px-3 py-2 no-underline hover:bg-brand-mid/20" :class="option.linkClass"
           >
-            <span class="block truncate text-sm">{option.name}</span>
-            <span class="block truncate text-xs opacity-60">{option.place}</span>
+            <span class="block truncate text-sm"><x-text of="option.name" /></span>
+            <span class="block truncate text-xs opacity-60"><x-text of="option.place" /></span>
           </a>
         </li>
         </x-each>


### PR DESCRIPTION
Stacked on #25. Removes the `{path}` syntax and with it every regular expression.

The premise: if templates are real HTML, the HTML parser should do all the work. `{path}`
was the one thing parse5 couldn't see — it lives inside text and attribute values, so it
had to be scanned for. Making every dynamic value an element or an attribute means
parse5 hands each one over structurally.

```
before   <a href="{urls.cv}" class="… {option.linkClass}">{option.name}</a>
after    <a :href="urls.cv" class="…" :class="option.linkClass"><x-text of="option.name" /></a>
```

`scripts/template.ts` and `scripts/i18n.ts` now contain no regular expressions at all —
not for interpolation, escaping, doctype detection, slots or whitespace.

## `:class` appends rather than replaces

Deliberate, and it fixes a bug from #25. Moving the locale-link class into the generator
took `text-brand`/`text-inherit` out of everything Tailwind scans and both were purged.
Keeping the literal utilities written in the template is what keeps Tailwind able to see
them; the bound value is appended.

## Escaping

`escape-html` — the one Express uses — rather than a hand-written character class.

## Cost

An attribute binds to exactly one path and cannot concatenate a literal prefix, so
`content="https://blit.cc{path}"` became `:content="canonicalUrl"`, built in
`generate.ts`. That is the general shape of the tradeoff: no expressions in templates
means composed values are composed in TypeScript.

## Verifying

- **72/72 pages structurally identical** to `main`'s output.
- **Compiled CSS byte-identical** — the check that caught the purge above.
- Unknown path and dead link both still fail the build; verified by injecting each.
- `oxlint` clean; it flagged four real issues in my own code, all fixed.

## Still open

Plurals, and `<i18n-t>` cannot interpolate a value mid-sentence.