### PR TITLE
feat: content-hash every asset and publish what was referenced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 .cache
 .env
 .deploy
+.build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### Assets are content-hashed and published on demand
+
+`dist/` is now built from what the templates referenced rather than copied out of
+`src/static/`, and every asset carries its content hash in its filename.
+
+- **`asset('logo.png')` returns `/logo.4d453d58.png`** and records the reference.
+  A name nothing provides fails the build listing what exists; a path written by hand
+  instead of through the helper fails too, because the link check now resolves `src`
+  as well as `href` against what was actually written.
+- **The hashing fixes a live staleness bug.** nano-web picks caching from the MIME
+  type alone — `is_asset()` matches `image/*` and `font/*`, not just CSS — so
+  `/logo.png` was being served `immutable, max-age=1y` at a stable URL. Replacing the
+  logo would have left returning visitors on the old one for a year.
+- **The stylesheet and the manifest are derived, not copied.** Both name other assets,
+  so they are rewritten before their own hash is taken; otherwise the font and the
+  icons would be fetched at a second, unhashed URL cached just as hard. Tailwind now
+  compiles to `.build` so that rewrite has a fixed input — rewriting in place appended
+  a second hash whenever Tailwind's output was already up to date.
+- **`favicon.ico` and `robots.txt` stay unhashed and always ship.** Their URLs are a
+  convention rather than ours to choose. This is where nano-web's MIME-based caching
+  bites: `/favicon.ico` is an image, so it is immutable for a year despite needing a
+  fixed path.
+- **`dist/` is pruned to exactly what was written**, so a superseded hash or a removed
+  locale's directory stops being served. The `static` copy task is gone.
+- Rendered pages are unchanged apart from the asset URLs: identical across all 72
+  pages once fingerprints are normalised.
+
+## Unreleased
+
 ### Templates are WebC, messages are Lingui
 
 The hand-rolled template engine and gettext extractor are gone. Templates are still

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,13 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ```bash
 task dev          # Rebuild on change, serve on :3000
-task build        # generate + css + static into dist/
+task build        # css into .build, then generate the site into dist/
 task generate     # Render the 72 pages only
 task check        # lint + format:check + typecheck, in parallel
 task ci           # What CI runs: check, then build
 task docker:build # Build the container image (PUSH/LATEST to publish)
 task i18n:sync    # Extract messages from the templates into every catalogue
-task clean        # Drop dist/ and Task's checksum cache
+task clean        # Drop dist/, .build/ and Task's checksum cache
 task lint         # oxlint  (task lint -- --fix to autofix)
 task format       # oxfmt --write
 task typecheck    # tsc --noEmit
@@ -80,14 +80,26 @@ Key decisions:
   syntax are its choice, not the template's. Compare renders structurally.
 - Pages are written as directory indexes (`dist/cv/index.html`) because nano-web
   resolves `/cv` to `/cv/`. Don't put extensions on internal links.
-- `task clean` must remove `.task` as well as `dist` — leaving the checksum cache makes
-  the next build skip steps whose output was just deleted.
-- `generate` prunes orphaned `index.html` files and empty directories. Without it a
-  removed locale keeps its directory in `dist/` and carries on being served.
-- `static` is deliberately unfingerprinted: its output is a directory rather than one
-  named file, so a partially-deleted `dist/` can't be detected. Copying is cheap.
-- `/style.css` carries a content digest as a query string. nano-web serves CSS
-  `immutable, max-age=1y`, so a stable URL would strand visitors on old styles.
+- `task clean` must remove `.task` and `.build` as well as `dist` — leaving the
+  checksum cache makes the next build skip steps whose output was just deleted.
+- Every asset reaches a page through `asset('logo.png')`, which publishes it under a
+  content hash (`/logo.4d453d58.png`) and records the reference. Writing the path by
+  hand instead fails the build, because the link check resolves `href` and `src`
+  against what was actually written.
+- Hashing is not decoration. nano-web picks caching by MIME type alone, so CSS,
+  images and fonts are all served `immutable, max-age=1y` — a stable URL is a promise
+  the build can't keep. `favicon.ico` and `robots.txt` are the exceptions: their URLs
+  are a convention, so they publish unhashed and always, and replacing one means
+  waiting the cache out.
+- `dist/` is written entirely by `generate`, which is what lets it delete anything
+  that is not a page or a referenced asset — a removed locale's directory, or the
+  previous hash of a file that has changed.
+- The stylesheet and the manifest are derived rather than copied: both name other
+  assets, so they are rewritten before their own hash is taken. Otherwise the font
+  and the icons get fetched at a second, unhashed URL that is cached just as hard.
+- Tailwind compiles to `.build`, not `dist`, so that rewrite has a fixed input.
+  Rewriting in place would append a second hash on any run where Tailwind's output
+  was already up to date.
 - Adding a page means a template plus an entry in `src/i18n/routes.ts`.
 - Tailwind scans `src/templates`, so a class chosen in `generate.ts` rather than
   written in a template is invisible to it.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ expression in an attribute, so extraction is a parse5 tree walk that hands those
 expressions to Lingui's own Babel extractor — nothing in this repo decides what
 counts as a message.
 
+## Assets
+
+Every asset reaches a page through `asset('logo.png')`, which publishes it under a
+content hash — `/logo.4d453d58.png` — and records that something wanted it. `dist/`
+is built from what was referenced rather than copied wholesale, so a file nothing
+points at stops shipping, a name nothing provides fails the build, and a path written
+by hand instead of through the helper fails too.
+
+The hashing is load-bearing rather than decorative: nano-web chooses caching by MIME
+type alone, so CSS, images and fonts are all served `immutable, max-age=1y`. A stable
+URL is a promise the build cannot keep. `favicon.ico` and `robots.txt` are the
+exceptions — their URLs are a convention, not ours to choose, so they publish unhashed
+and unconditionally.
+
+The stylesheet and the web app manifest name other assets, so both are rewritten
+before their own hash is taken; otherwise the font and the icons would also be fetched
+at a second, unhashed URL that is cached just as hard.
+
 The source locale is served at `/` and `/cv`; every other locale is prefixed
 (`/fr-FR`, `/fr-FR/cv`). Pages are written as directory indexes — nano-web resolves
 `/cv` to `/cv/index.html`, so URLs stay extensionless without a redirect.
@@ -99,9 +117,9 @@ The source locale is served at `/` and `/cv`; every other locale is prefixed
 
 ## Adding things
 
-A **string**: add it to `src/locales/en-GB/messages.po`, reference it as `{{t.key}}`,
-then run `task i18n:sync`. A **page**: add a template and an entry in
-`src/i18n/routes.ts`.
+A **string**: write it in a template as `i18n._('the english text')`, then run
+`task i18n:sync`. A **page**: add a template and an entry in `src/i18n/routes.ts`.
+An **asset**: drop it in `src/static/` and reference it with `asset('name.ext')`.
 
 ## Deployment
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,9 @@ version: "3"
 
 vars:
   DIST: dist
+  # Tailwind's output is an input to generate, which rewrites it; keeping it out of
+  # dist gives that rewrite a fixed input and leaves dist owned by generate alone.
+  BUILD: .build
   BIN: ./node_modules/.bin
   IMAGE: ghcr.io/radiosilence/blit
   PLATFORMS: linux/amd64
@@ -25,7 +28,7 @@ tasks:
 
   build:
     desc: Generate the whole site into dist/
-    deps: [generate, static]
+    deps: [generate]
 
   # Depends on css because it fingerprints the compiled stylesheet into the URL.
   generate:
@@ -36,8 +39,9 @@ tasks:
       - src/content/**/*.md
       - src/i18n/**/*.ts
       - src/locales/**/*.po
+      - src/static/**/*
       - src/templates/**/*.html
-      - "{{.DIST}}/style.css"
+      - "{{.BUILD}}/style.css"
     generates:
       - "{{.DIST}}/**/index.html"
     cmd: node scripts/generate.ts
@@ -50,17 +54,8 @@ tasks:
       - src/styles/**/*.css
       - src/templates/**/*.html
     generates:
-      - "{{.DIST}}/style.css"
-    cmd: "{{.BIN}}/tailwindcss --input src/styles/app.css --output {{.DIST}}/style.css --minify"
-
-  # Deliberately unfingerprinted: the outputs are a whole directory rather than one
-  # named file, so a partially-deleted dist/ can't be detected. Copying ~1 MB takes
-  # a few ms, which is cheaper than the class of bug where assets silently vanish.
-  static:
-    desc: Copy fonts, icons and manifest
-    cmds:
-      - mkdir -p {{.DIST}}
-      - cp -R src/static/. {{.DIST}}/
+      - "{{.BUILD}}/style.css"
+    cmd: "{{.BIN}}/tailwindcss --input src/styles/app.css --output {{.BUILD}}/style.css --minify"
 
   dev:
     desc: Rebuild on change, serve on :3000
@@ -80,7 +75,7 @@ tasks:
     desc: Remove generated output
     # .task holds the source checksums; leaving it makes the next build skip
     # steps whose output was just deleted.
-    cmd: rm -rf {{.DIST}} .task
+    cmd: rm -rf {{.DIST}} {{.BUILD}} .task
 
   lint:
     desc: Lint with oxlint

--- a/scripts/assets.ts
+++ b/scripts/assets.ts
@@ -1,0 +1,92 @@
+/**
+ * Every published asset carries its content hash in its filename, so a URL only
+ * ever maps to one set of bytes.
+ *
+ * nano-web decides caching from the MIME type alone — CSS, images and fonts are all
+ * served `max-age=31536000, immutable` — so a stable URL is a promise the build
+ * cannot keep: replace a file and a returning visitor holds the old bytes for a
+ * year. A hashed name makes the promise true rather than giving up the caching.
+ *
+ * Publishing what was referenced, rather than copying the directory, means a file
+ * nothing points at stops shipping and a name nothing provides fails the build.
+ */
+import { createHash } from "node:crypto";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+
+/*
+ * These URLs are a convention rather than ours to choose: a browser asks for
+ * /favicon.ico when a page links no icon, and a crawler asks for /robots.txt.
+ * Nothing links them, so they publish unhashed and unconditionally.
+ *
+ * This is where nano-web's MIME-based caching bites — /favicon.ico is an image and
+ * so served immutable for a year, while needing a fixed path. Replacing it means
+ * waiting the cache out.
+ */
+const FIXED = new Set(["favicon.ico", "robots.txt"]);
+
+const digest = (body: Buffer) => createHash("sha256").update(body).digest("hex").slice(0, 8);
+
+/** `logo.png` becomes `logo.a1b2c3d4.png`; a name with no extension gets one appended. */
+function fingerprint(name: string, body: Buffer) {
+  const dot = name.lastIndexOf(".");
+  const hash = digest(body);
+  return dot === -1 ? `${name}.${hash}` : `${name.slice(0, dot)}.${hash}${name.slice(dot)}`;
+}
+
+export async function loadAssets(dir: string) {
+  const entries = await readdir(dir, { recursive: true, withFileTypes: true });
+  const bodies: Map<string, Buffer> = new Map(
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isFile())
+        .map(async (entry) => {
+          const path = join(entry.parentPath, entry.name);
+          return [relative(dir, path), await readFile(path)] as const;
+        }),
+    ),
+  );
+
+  const used = new Set(FIXED);
+  const nameOf = (name: string, body: Buffer) => (FIXED.has(name) ? name : fingerprint(name, body));
+
+  /**
+   * Supplies or replaces an asset's bytes before anything asks for its URL. The
+   * stylesheet and the manifest are built rather than copied, because both name
+   * other assets and so have to be rewritten before they can be hashed themselves.
+   */
+  const derive = (name: string, body: Buffer) => {
+    bodies.set(name, body);
+  };
+
+  /** The URL for an asset, recording that something wanted it. */
+  const href = (name: string) => {
+    const body = bodies.get(name);
+    if (!body) {
+      const available = [...bodies.keys()].toSorted().join(", ");
+      throw new Error(`No asset \`${name}\`. Available: ${available}`);
+    }
+
+    used.add(name);
+    return `/${nameOf(name, body)}`;
+  };
+
+  /** Writes what was referenced, and returns it so a dead link differs from a dead file. */
+  const publish = async (dist: string) => {
+    const written = await Promise.all(
+      [...used].map(async (name) => {
+        const body = bodies.get(name);
+        if (!body) throw new Error(`Referenced but not present: ${name}`);
+
+        const file = join(dist, nameOf(name, body));
+        await mkdir(dirname(file), { recursive: true });
+        await writeFile(file, body);
+        return file;
+      }),
+    );
+
+    return new Set(written);
+  };
+
+  return { href, derive, publish };
+}

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { glob, mkdir, readdir, readFile, rm, rmdir, writeFile } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -9,30 +8,51 @@ import { generateMessageId } from "@lingui/message-utils/generateMessageId";
 import MarkdownIt from "markdown-it";
 import { parse } from "parse5";
 
+import { loadAssets } from "./assets.ts";
+
 import { loadCatalogs } from "#/i18n/catalogs.ts";
 import { describeLocale, isRtl, locales } from "#/i18n/config.ts";
 import { pages, url } from "#/i18n/routes.ts";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
 const dist = join(root, "dist");
+const build = join(root, ".build");
 
 const read = (...path: string[]) => readFile(join(root, ...path), "utf8");
 
 const markdown = MarkdownIt({ html: true });
 
-/*
- * nano-web serves CSS as `immutable, max-age=1y`, so a stable /style.css would
- * strand returning visitors on old styles after a deploy. The digest changes the
- * URL whenever the CSS does, which is what makes that caching safe.
- */
-const styleHref = await readFile(join(dist, "style.css")).then(
-  (css) => `/style.css?v=${createHash("sha256").update(css).digest("hex").slice(0, 8)}`,
-);
-
-const [catalogs, cv] = await Promise.all([
+const [assets, catalogs, cv] = await Promise.all([
+  loadAssets(join(root, "src/static")),
   loadCatalogs(),
   read("src/content/cv.md").then((source) => markdown.render(source)),
 ]);
+
+/*
+ * The stylesheet and the manifest name other assets, so both are rewritten before
+ * anything asks for their own URL — a hashed name inside them is what stops the
+ * font and the icons being fetched at a second, unhashed URL that is cached just
+ * as immutably.
+ *
+ * Tailwind compiles to .build rather than dist so that this rewrite has a fixed
+ * input. Reading and rewriting in place would append a second hash on any run
+ * where Tailwind's own output was up to date and therefore not regenerated.
+ */
+const fontUrl = assets.href("geist-mono.woff2");
+assets.derive(
+  "style.css",
+  Buffer.from(
+    (await readFile(join(build, "style.css"), "utf8")).replaceAll("/geist-mono.woff2", fontUrl),
+  ),
+);
+
+const manifest = JSON.parse(await read("src/static/manifest.json")) as {
+  icons?: { src: string }[];
+};
+for (const icon of manifest.icons ?? []) {
+  icon.src = assets.href(icon.src.startsWith("/") ? icon.src.slice(1) : icon.src);
+}
+assets.derive("manifest.json", Buffer.from(JSON.stringify(manifest, null, 2)));
 
 /*
  * Message ids are the source text, so Lingui's default of falling back to the id
@@ -106,13 +126,13 @@ const written = await Promise.all(
       template.defineComponents(join(root, "src/templates/*.html"));
       // A helper is unscoped, so it reaches nested components; page data does not.
       template.setHelper("i18n", i18n);
+      template.setHelper("asset", assets.href);
 
       const { html } = await template.compile({
         data: strict({
           locale,
           dir: isRtl(locale) ? "rtl" : "ltr",
           cv,
-          styleHref,
           canonicalUrl: `https://blit.cc${path}`,
           urls: Object.fromEntries(pages.map(({ slug }) => [slug || "home", url(locale, slug)])),
           localeLinks: locales.map((code) => ({
@@ -132,17 +152,22 @@ const written = await Promise.all(
   }),
 );
 
+const publishedAssets = await assets.publish(dist);
+
 /*
- * Drop pages from earlier builds. Without this a removed locale keeps its
- * directory in dist/ and carries on being served. Only index.html files are
- * touched, which is exactly the set this script owns.
+ * Drop everything from earlier builds. dist/ is written entirely by this script, so
+ * anything in it that is not a page or a referenced asset is left over — a removed
+ * locale's directory, or the previous hash of a file that has since changed, both
+ * of which would otherwise carry on being served.
  */
-const current = new Set(written);
+const current = new Set([...written, ...publishedAssets]);
 const stale: string[] = [];
-for await (const page of glob("*/**/index.html", { cwd: dist })) {
-  if (!current.has(join(dist, page))) stale.push(join(dist, page));
+for await (const entry of glob("**/*", { cwd: dist, withFileTypes: true })) {
+  if (!entry.isFile()) continue;
+  const file = join(entry.parentPath, entry.name);
+  if (!current.has(file)) stale.push(file);
 }
-await Promise.all(stale.map((page) => rm(page)));
+await Promise.all(stale.map((file) => rm(file)));
 
 // Depth-first: children have to be gone before a directory can be judged empty.
 const prune = async (dir: string) => {
@@ -156,9 +181,11 @@ const prune = async (dir: string) => {
 await prune(dist);
 
 /*
- * Every internal link, resolved against what was actually written. Pages are
- * directory indexes and the templates build hrefs from routes.ts, so a link that
- * misses is a routing bug that would otherwise ship as a 404 nobody clicks.
+ * Every absolute reference a page makes, resolved against what was actually
+ * written. A link that misses is a routing bug and an `src` that misses is an asset
+ * written by hand instead of through `asset()`; both would ship as a 404 nobody
+ * clicks. Pages are directory indexes, so a link resolves to that directory's
+ * index.html while an asset resolves to the file itself.
  */
 const broken: string[] = [];
 
@@ -173,11 +200,16 @@ for (const [file, html] of rendered) {
       attrs?: { name: string; value: string }[];
       childNodes?: unknown[];
     }[]) {
-      const href = child.attrs?.find((a) => a.name === "href")?.value;
-      if (child.tagName === "a" && href?.startsWith("/")) {
-        const [path] = href.split("?");
-        const target = join(dist, path?.split("#")[0] ?? "", "index.html");
-        if (!current.has(target)) broken.push(`${relative(dist, file)} -> ${href}`);
+      for (const { name, value } of child.attrs ?? []) {
+        if ((name !== "href" && name !== "src") || !value.startsWith("/")) continue;
+
+        const [withoutQuery] = value.split("?");
+        const path = withoutQuery?.split("#")[0] ?? "";
+        const target = join(dist, path);
+
+        if (!current.has(target) && !current.has(join(target, "index.html"))) {
+          broken.push(`${relative(dist, file)} -> ${value}`);
+        }
       }
       walkLinks(child);
     }
@@ -186,8 +218,10 @@ for (const [file, html] of rendered) {
 }
 
 if (broken.length) {
-  throw new Error(`Links with no page behind them:\n  ${[...new Set(broken)].join("\n  ")}`);
+  throw new Error(`References with nothing behind them:\n  ${[...new Set(broken)].join("\n  ")}`);
 }
 
-console.log(`Checked internal links across ${written.length} pages`);
+console.log(
+  `Checked links and assets across ${written.length} pages; published ${publishedAssets.size} assets`,
+);
 console.log(`Generated ${locales.length * pages.length} pages in ${dist}`);

--- a/src/templates/cv.html
+++ b/src/templates/cv.html
@@ -2,7 +2,7 @@
   <div class="mx-4 flex flex-col items-center lg:mx-0">
     <section class="mb-12 max-w-5xl">
       <a :href="$data.urls.home">
-        <img src="/logo.png" alt="blit.cc logo" width="128" height="128" class="mt-16 mb-8 lg:mt-32" />
+        <img :src="asset('logo.png')" alt="blit.cc logo" width="128" height="128" class="mt-16 mb-8 lg:mt-32" />
       </a>
       <article class="prose prose-sm" @html="$data.cv"></article>
     </section>

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,6 +1,6 @@
 <page-base>
   <section class="m-12 flex flex-col items-center space-y-4 text-center">
-    <img src="/logo.png" alt="blit.cc logo" width="256" height="256" class="mt-12 mb-8" />
+    <img :src="asset('logo.png')" alt="blit.cc logo" width="256" height="256" class="mt-12 mb-8" />
     <h1 @text="i18n._('james cleveland')"></h1>
     <p class="text-sm" @text="i18n._('james cleveland : senior full stack engineer')"></p>
     <p>

--- a/src/templates/page-base.html
+++ b/src/templates/page-base.html
@@ -17,14 +17,14 @@
       :content="i18n._('james cleveland : senior full stack engineer')"
     />
     <meta property="og:url" :content="$data.canonicalUrl" />
-    <meta property="og:image" content="https://blit.cc/logo.png" />
+    <meta property="og:image" :content="`https://blit.cc${asset('logo.png')}`" />
 
-    <link rel="stylesheet" :href="$data.styleHref" />
-    <link rel="preload" href="/geist-mono.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="stylesheet" :href="asset('style.css')" />
+    <link rel="preload" :href="asset('geist-mono.woff2')" as="font" type="font/woff2" crossorigin />
+    <link rel="apple-touch-icon" sizes="180x180" :href="asset('apple-touch-icon.png')" />
+    <link rel="icon" type="image/png" sizes="32x32" :href="asset('favicon-32x32.png')" />
+    <link rel="icon" type="image/png" sizes="16x16" :href="asset('favicon-16x16.png')" />
+    <link rel="manifest" :href="asset('manifest.json')" />
   </head>
 
   <body>


### PR DESCRIPTION
Stacked on #30 so the diff is only this change; it retargets to `main` when #30 merges.

`dist/` is now built from what the templates referenced rather than copied out of
`src/static/`, and every published asset carries its content hash in its filename:

```
dist/logo.4d453d58.png
dist/style.49bc306b.css
dist/geist-mono.2361fdef.woff2
dist/manifest.65522482.json
dist/favicon.ico          ← fixed by convention
dist/robots.txt           ← fixed by convention
```

## This fixes a live bug, not just ergonomics

nano-web picks caching from the MIME type alone — `is_asset()` in `mime_types.rs`
matches `image/*` and `font/*`, not only CSS:

```rust
if is_asset(mime_type) {
    "public, max-age=31536000, immutable" // 1 year
}
```

So `/logo.png` was **already** being served immutable for a year at a stable URL.
Replacing the logo would have left returning visitors on the old one until the cache
expired. Only `style.css` was fingerprinted, and only because it had been noticed.

## Load-bearing decisions

- **The stylesheet and the manifest are derived, not copied.** Both name other assets,
  so they are rewritten before their own hash is taken — the `@font-face` URL and the
  manifest's `icons[].src` now point at hashed names. Without this the font and the
  icons get fetched at a second, unhashed URL that is cached just as hard, and the
  preload stops matching what the stylesheet asks for.
- **Tailwind compiles to `.build`, not `dist`.** The CSS rewrite needs a fixed input;
  rewriting in place appended a second hash on any run where Tailwind's own output was
  already up to date. This also leaves `dist/` written entirely by `generate`, which is
  what makes the prune below safe.
- **`favicon.ico` and `robots.txt` publish unhashed and always.** A browser asks for
  `/favicon.ico` when a page links no icon and a crawler asks for `/robots.txt`, so
  their URLs are a convention rather than ours to choose.
- **Manifest icons are discovered from the manifest**, not a hand-kept list, so adding
  an icon there cannot silently 404.
- **`dist/` is pruned to exactly what was written**, so a superseded hash or a removed
  locale's directory stops being served. The `static` copy task is gone.

## Verifying

`task ci` is green. Beyond that:

- **Rendered pages are unchanged apart from asset URLs** — 72/72 identical against a
  build of #30 once fingerprints are normalised.
- **Idempotent**: two consecutive builds produce identical filenames.
- **Stale pruning**: changing `logo.png` replaced `logo.4d453d58.png` with
  `logo.16fee1aa.png` and removed the old file.
- **Failure modes**, both injected and confirmed:
  - `asset('logl.png')` → ``No asset `logl.png`. Available: android-chrome-192x192.png, …``
  - `src="/logo.png"` written by hand → `References with nothing behind them: index.html -> /logo.png`
- **Derived output checked**: the compiled CSS contains `url(/geist-mono.2361fdef.woff2)`
  and all five manifest icons are hashed.

## Known limitation

`/favicon.ico` is `image/x-icon`, so nano-web serves it immutable for a year while it
also needs a fixed path — replacing it means waiting the cache out. That is a
consequence of choosing cache headers by MIME type rather than by whether a URL is
fingerprinted; nothing this repo can fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFseKeQBn4jEUrrKhyki4p