### PR TITLE
docs: nano-web is a dev dependency, and other things that went stale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,9 @@ framework and no bundler — the browser receives HTML, CSS and a font, nothing 
 - **i18n**: `crates/askama_gettext` — plain gettext `.po`, 36 locales, CLDR plurals
 - **Content**: pulldown-cmark renders `src/content/cv.md`
 - **Styling**: TailwindCSS v4 CLI, Geist Mono
-- **Toolchain**: mise (`mise.toml`) — rust, task, tailwind, nano-web, gh, yq
+- **Toolchain**: mise (`mise.toml`) — rust, task, tailwind, gh, yq. nano-web is not
+  pinned there: it serves `dist/` for `task dev`, and nothing the build does needs a
+  server
 - **Deployment**: Docker → microk8s → CloudFlare Tunnel
 
 Key decisions:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The browser gets HTML, CSS and a font. No JavaScript at all.
 
 ## Why there's no framework
 
-The site is a couple of pages, a dozen translated strings and a markdown CV. Its only piece of
+The site is two pages, seven translated strings and a markdown CV. Its only piece of
 interactivity is the language picker, so there was nothing for a client-side
 framework to do.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The browser gets HTML, CSS and a font. No JavaScript at all.
 
 ## Why there's no framework
 
-The site is two pages, six translated strings and a markdown CV. Its only piece of
+The site is a couple of pages, a dozen translated strings and a markdown CV. Its only piece of
 interactivity is the language picker, so there was nothing for a client-side
 framework to do.
 
@@ -28,8 +28,10 @@ principle is to lean on native elements for _behaviour_ and style them ourselves
 This costs pre-2025 browsers: without `command` support the button does nothing.
 Two lines of feature-detected script would buy that back if it ever matters.
 
-Locale names come from ICU via `Intl.DisplayNames` at build time, so the picker
-reads "日本語 / 日本" rather than "ja-JP" at no runtime cost.
+Locale names are endonyms — the picker reads "日本語 / 日本" rather than "ja-JP".
+They come from ICU, resolved once into `generator/config.rs` rather than at build
+time, because ICU4X exposes display names only in `icu_experimental` and this is data
+that changes about as often as a language renames itself.
 
 ## Stack
 
@@ -42,8 +44,9 @@ reads "日本語 / 日本" rather than "ja-JP" at no runtime cost.
 - [pulldown-cmark](https://github.com/pulldown-cmark/pulldown-cmark) renders the CV,
   passing through the inline HTML it already contained
 - [TailwindCSS](https://tailwindcss.com) v4 with Geist Mono
-- Everything is pinned in [mise](https://mise.jdx.dev): rust, task, tailwind,
-  nano-web, gh, yq
+- Everything the build needs is pinned in [mise](https://mise.jdx.dev): rust, task,
+  tailwind, gh, yq. [nano-web](https://github.com/radiosilence/nano-web) serves
+  `dist/` for `task dev` and is yours to install
 
 The build is a Rust binary. Tailwind is the only JavaScript left in it — its
 compiler genuinely is TypeScript, and Oxide is only the scanner — so it arrives as a
@@ -107,13 +110,13 @@ The source locale is served at `/` and `/cv`; every other locale is prefixed
 | Command             | Notes                                              |
 | ------------------- | -------------------------------------------------- |
 | `task dev`          | Rebuild on change, serve on :3000                  |
-| `task build`        | Generate, compile CSS and copy assets into `dist/` |
-| `task generate`     | Render the 72 pages only                           |
-| `task check`        | Lint, formatting and types                         |
+| `task build`        | Compile CSS, then generate the site into `dist/`   |
+| `task generate`     | Render every locale × page only                    |
+| `task check`        | Clippy, rustfmt and tests                          |
 | `task ci`           | Exactly what CI runs — `check`, then `build`       |
 | `task docker:build` | Build the container image                          |
 | `task i18n:sync`    | Sync locale catalogues against the source          |
-| `task clean`        | Drop `dist/` and Task's checksum cache             |
+| `task clean`        | Drop `dist/`, `.build/`, `target/` and the cache   |
 
 `task --list` shows the rest.
 
@@ -141,6 +144,7 @@ task deploy:update SHA=$(git rev-parse HEAD)   # what points prod at it
 ```
 
 Anything a runner has and a laptop doesn't arrives as environment rather than as
-workflow logic: `CI` selects `--frozen-lockfile`, `CACHE_FROM`/`CACHE_TO` select
-GitHub's buildx cache over the local one, `GH_TOKEN` authorises the push to the IaC
-repo. Unset, each falls back to the local equivalent.
+workflow logic: `CI` selects an optimised build over the fast debug one the watch loop
+wants, `CACHE_FROM`/`CACHE_TO` select GitHub's buildx cache over the local one, and
+`GH_TOKEN` authorises the push to the IaC repo. Unset, each falls back to the local
+equivalent.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -99,7 +99,7 @@ tasks:
         msg: |
           nano-web is not on PATH. It serves dist/ for `task dev` and is not part of
           the build toolchain, so it is not pinned in mise.toml.
-          Install it with: mise use -g nano-web
+          https://github.com/radiosilence/nano-web
     cmd: nano-web serve {{.DIST}} --port 3000 --dev
 
   clean:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,8 +89,17 @@ tasks:
 
   # The same server the image runs, so dev resolves URLs exactly as production does.
   # --dev drops the year-long caching it serves with, so a rebuild is picked up.
+  #
+  # Deliberately not in mise.toml: that pins what the build needs, and nothing in
+  # `task build` or CI touches a server. Bring your own.
   serve:
     internal: true
+    preconditions:
+      - sh: command -v nano-web
+        msg: |
+          nano-web is not on PATH. It serves dist/ for `task dev` and is not part of
+          the build toolchain, so it is not pinned in mise.toml.
+          Install it with: mise use -g nano-web
     cmd: nano-web serve {{.DIST}} --port 3000 --dev
 
   clean:

--- a/crates/askama_gettext/src/merge.rs
+++ b/crates/askama_gettext/src/merge.rs
@@ -202,7 +202,12 @@ mod tests {
              msgstr[0] \"%{{count}} język\"\nmsgstr[1] \"%{{count}} języki\"\nmsgstr[2] \"%{{count}} języków\"\n"
         ));
 
-        into_catalog(&path, "pl-PL", &[site("%{count} locale", Some("%{count} locales"))]).unwrap();
+        into_catalog(
+            &path,
+            "pl-PL",
+            &[site("%{count} locale", Some("%{count} locales"))],
+        )
+        .unwrap();
 
         let after = std::fs::read_to_string(&path).unwrap();
         assert!(after.contains("język\""), "singular form lost:\n{after}");
@@ -223,7 +228,9 @@ mod tests {
 
     #[test]
     fn a_new_message_arrives_untranslated_and_is_counted() {
-        let path = catalogue(&format!("{PL_HEADER}\n#: t.html:1\nmsgid \"old\"\nmsgstr \"stary\"\n "));
+        let path = catalogue(&format!(
+            "{PL_HEADER}\n#: t.html:1\nmsgid \"old\"\nmsgstr \"stary\"\n "
+        ));
 
         let summary =
             into_catalog(&path, "pl-PL", &[site("old", None), site("new", None)]).unwrap();
@@ -264,7 +271,10 @@ mod atomicity {
         assert!(into_catalog(&path, "pl-PL", &sites).is_err());
 
         let after = std::fs::read_to_string(&path).unwrap();
-        assert!(after.contains("zamknij"), "translation lost on a failed merge");
+        assert!(
+            after.contains("zamknij"),
+            "translation lost on a failed merge"
+        );
         assert!(!path.with_extension("po.tmp").exists() || after == original);
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,8 @@
 [tools]
-# The generator and the extractor.
-rust = "1"
+# The generator and the extractor. `task check` runs rustfmt and clippy, which the
+# minimal profile leaves out — a laptop tends to have them from rustup already, a
+# clean runner does not.
+rust = { version = "1", components = "rustfmt,clippy" }
 task = "latest"
 # Tailwind is the one part of the build that is still JavaScript — its compiler is
 # TypeScript, and Oxide is only the scanner — so it arrives as a pinned tool rather


### PR DESCRIPTION
Follow-up to `unfcuk mise` on main — the docs still claimed mise pins nano-web.

## nano-web

`mise.toml` pins what the *build* needs, and nothing in `task build` or CI touches a
server. nano-web only serves `dist/` for `task dev`.

So rather than putting it back, `task serve` now says so itself:

```
nano-web is not on PATH. It serves dist/ for `task dev` and is not part of
the build toolchain, so it is not pinned in mise.toml.
https://github.com/radiosilence/nano-web
```

Better than `"nano-web": executable file not found in $PATH`, which is what anyone
cloning this hits first. It links rather than prescribing `mise use -g`, which would
be a global install to fix a project-local gap.

## Other things the Rust rewrite invalidated

Found while checking that one:

- **Locale endonyms.** The README said they come from `Intl.DisplayNames` at build
  time. They come from a table resolved once into `generator/config.rs`, because
  ICU4X exposes display names only in `icu_experimental` and this is data that
  changes about as often as a language renames itself.
- **`CI` selects `--frozen-lockfile`.** There is no lockfile to freeze. It selects an
  optimised build over the fast debug one the watch loop wants.
- `task check` runs clippy, rustfmt and tests, not a typecheck.
- `task clean` drops `target/` and `.build/` as well as `dist/`.
- `task generate` renders every locale × page rather than "the 72 pages" — that count
  is a fact about the routes, and repeating it here means restating it every time
  they change.

The page and string counts under "Why there's no framework" are now the real ones,
which is only worth stating because they are small enough to be the argument.

## Verifying

`task ci` is green on this branch — the first time it has been since #32, because
cc33b50 and 6fadda9 are what let `check` run at all.

## Merge order

After #35, which is what makes "two pages, seven translated strings" true. Landing
this first is not broken, just briefly wrong by five strings and a page.
