### PR TITLE
ci: task check passes again

### DIFF
--- a/crates/askama_gettext/src/merge.rs
+++ b/crates/askama_gettext/src/merge.rs
@@ -202,7 +202,12 @@ mod tests {
              msgstr[0] \"%{{count}} język\"\nmsgstr[1] \"%{{count}} języki\"\nmsgstr[2] \"%{{count}} języków\"\n"
         ));
 
-        into_catalog(&path, "pl-PL", &[site("%{count} locale", Some("%{count} locales"))]).unwrap();
+        into_catalog(
+            &path,
+            "pl-PL",
+            &[site("%{count} locale", Some("%{count} locales"))],
+        )
+        .unwrap();
 
         let after = std::fs::read_to_string(&path).unwrap();
         assert!(after.contains("język\""), "singular form lost:\n{after}");
@@ -223,7 +228,9 @@ mod tests {
 
     #[test]
     fn a_new_message_arrives_untranslated_and_is_counted() {
-        let path = catalogue(&format!("{PL_HEADER}\n#: t.html:1\nmsgid \"old\"\nmsgstr \"stary\"\n "));
+        let path = catalogue(&format!(
+            "{PL_HEADER}\n#: t.html:1\nmsgid \"old\"\nmsgstr \"stary\"\n "
+        ));
 
         let summary =
             into_catalog(&path, "pl-PL", &[site("old", None), site("new", None)]).unwrap();
@@ -264,7 +271,10 @@ mod atomicity {
         assert!(into_catalog(&path, "pl-PL", &sites).is_err());
 
         let after = std::fs::read_to_string(&path).unwrap();
-        assert!(after.contains("zamknij"), "translation lost on a failed merge");
+        assert!(
+            after.contains("zamknij"),
+            "translation lost on a failed merge"
+        );
         assert!(!path.with_extension("po.tmp").exists() || after == original);
     }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,9 @@
 [tools]
-# The generator and the extractor.
-rust = "1"
+# The generator and the extractor. `task check` needs clippy and rustfmt, and an
+# unset profile means whatever rustup the host already had is configured for — which
+# on a GitHub runner is minimal, so neither is there. Naming both makes the toolchain
+# the same everywhere rather than the same as the machine.
+rust = { version = "1", profile = "minimal", components = ["clippy", "rustfmt"] }
 task = "latest"
 # Tailwind is the one part of the build that is still JavaScript — its compiler is
 # TypeScript, and Oxide is only the scanner — so it arrives as a pinned tool rather


### PR DESCRIPTION
`main` has been red since the Rust generator landed in #32, for two unrelated reasons.

## clippy and rustfmt were never installed

`mise.toml` pinned `rust = "1"` and said nothing about the profile, which mise reads as "whatever this machine's rustup is already configured for". A laptop that has ever run `rustup component add` has clippy and rustfmt; the GitHub runner image is set to minimal and has neither:

```
error: 'cargo-clippy' is not installed for the toolchain '1.97.1-x86_64-unknown-linux-gnu'
error: 'cargo-fmt' is not installed for the toolchain '1.97.1-x86_64-unknown-linux-gnu'
```

Before that surfaced it presented as a download race, because `check` runs `lint`, `format:check` and `test` as parallel deps: three cargo processes each had rustup try to fetch the missing pieces at once, through the one download directory it sweeps on the way out, and the losers failed to rename a file into a path that no longer existed. Installing the components up front removes the on-demand download, and with it the race.

Naming `profile` as well as `components` is deliberate — leaving the profile unset is what made the toolchain depend on the host in the first place, and `minimal` plus the two we actually use is smaller than `default`, which would also pull `rust-docs`.

## The formatting

Three expressions in `merge.rs` sit over rustfmt's 100-column default. `format:check` has been failing on them since #32; nobody saw it because Task surfaces one failed dep and it reported `lint`.

## Verifying

`task check`. The host-independence claim is only really testable on a runner, so the CI run on this branch is the check that matters.