### PR TITLE
test: render the i18n surface through Askama

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
 name = "askama_gettext"
 version = "0.1.0"
 dependencies = [
+ "askama",
  "askama_parser",
  "icu_locale_core",
  "icu_plurals",

--- a/crates/askama_gettext/Cargo.toml
+++ b/crates/askama_gettext/Cargo.toml
@@ -10,6 +10,11 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/radiosilence/blit"
 readme = "README.md"
 
+# Askama is not a dependency: the crate is what a template calls, and never calls
+# it. Rendering one is how the tests check that, so it is needed only there.
+[dev-dependencies]
+askama = "0.16"
+
 [dependencies]
 askama_parser = "0.16"
 icu_locale_core = "2"

--- a/crates/askama_gettext/templates/i18n.html
+++ b/crates/askama_gettext/templates/i18n.html
@@ -1,0 +1,24 @@
+{#
+  Every shape the crate offers, rendered by Askama the way a page would.
+
+  Kept out of any site's own template directory on purpose: extraction walks the
+  templates a site declares, and these ids are fixtures rather than copy.
+#}
+<p id="translated">{{ __("Book now") }}</p>
+<p id="from-source">{{ __("Sign in") }}</p>
+<p id="untranslated">{{ __("Nobody has translated this") }}</p>
+
+<p id="context-dialog">{{ __p("A button that dismisses a dialog", "close") }}</p>
+<p id="context-distance">{{ __p("How near something is", "close") }}</p>
+
+<p id="one">{{ __n("%{count} file", "%{count} files", 1) }}</p>
+<p id="few">{{ __n("%{count} file", "%{count} files", 2) }}</p>
+<p id="many">{{ __n("%{count} file", "%{count} files", 5) }}</p>
+
+<p id="interpolated">{{ __("showing %{shown} of %{total}").with("shown", 3).with("total", 36) }}</p>
+
+<p id="markup">{{ __h("read my <cv>CV</cv>").link("cv", cv)|safe }}</p>
+
+{# A catalogue is data, so neither of these may reach the page as markup. #}
+<p id="hostile-text">{{ __("<script>alert(1)</script>") }}</p>
+<p id="hostile-markup">{{ __h("<script>alert(1)</script> and <b>not bold</b>")|safe }}</p>

--- a/crates/askama_gettext/tests/locales/en-GB/messages.po
+++ b/crates/askama_gettext/tests/locales/en-GB/messages.po
@@ -1,0 +1,12 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en-GB\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+# Translated here and nowhere else, so a locale that lacks it has somewhere to
+# fall back to that is not simply the id.
+msgid "Sign in"
+msgstr "Log in"

--- a/crates/askama_gettext/tests/locales/pl-PL/messages.po
+++ b/crates/askama_gettext/tests/locales/pl-PL/messages.po
@@ -1,0 +1,40 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pl-PL\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+
+msgid "Book now"
+msgstr "Zarezerwuj teraz"
+
+msgctxt "A button that dismisses a dialog"
+msgid "close"
+msgstr "zamknij"
+
+msgctxt "How near something is"
+msgid "close"
+msgstr "blisko"
+
+msgid "%{count} file"
+msgid_plural "%{count} files"
+msgstr[0] "%{count} plik"
+msgstr[1] "%{count} pliki"
+msgstr[2] "%{count} plików"
+
+msgid "showing %{shown} of %{total}"
+msgstr "pokazano %{shown} z %{total}"
+
+# The link has moved to the front, which is the point of naming it rather than
+# handing a translator two fragments and an <a>.
+msgid "read my <cv>CV</cv>"
+msgstr "mój <cv>życiorys</cv> jest tutaj"
+
+# A hostile catalogue. Neither of these is markup the code allowed.
+msgid "<script>alert(1)</script>"
+msgstr "<script>alert(2)</script>"
+
+msgid "<script>alert(1)</script> and <b>not bold</b>"
+msgstr "<img src=x onerror=alert(3)> i <b>nie pogrubione</b>"

--- a/crates/askama_gettext/tests/render.rs
+++ b/crates/askama_gettext/tests/render.rs
@@ -1,0 +1,125 @@
+//! The whole surface, rendered by Askama against catalogues on disk.
+//!
+//! The unit tests reach each piece on its own — interpolation, markup, plural
+//! selection, lookup. What none of them covers is the join: that Askama resolves a
+//! bare `__(…)` to the trait method, that a `Message` goes through the HTML escaper
+//! and a `Markup` past it, and that a `.po` file on disk is what decides any of it.
+//! Everything here goes through `Template::render`.
+
+use std::path::Path;
+
+use askama::Template;
+use askama_gettext::{Catalogs, Translate, Translator};
+
+#[derive(Template)]
+#[template(path = "i18n.html")]
+struct Page<'a> {
+    catalogs: &'a Catalogs,
+    locale: &'a str,
+    cv: &'a str,
+}
+
+impl Translate for Page<'_> {
+    fn translator(&self) -> Translator<'_> {
+        Translator::new(self.catalogs, self.locale)
+    }
+}
+
+fn render(locale: &str) -> String {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/locales");
+    let catalogs = Catalogs::load(&dir, &["en-GB", "pl-PL"], "en-GB").unwrap();
+
+    Page {
+        catalogs: &catalogs,
+        locale,
+        cv: "/pl-PL/cv",
+    }
+    .render()
+    .unwrap()
+}
+
+/// The text of one `<p id="…">`, so an assertion names what it is reading.
+fn part<'a>(html: &'a str, id: &str) -> &'a str {
+    let open = format!("<p id=\"{id}\">");
+    let start = html
+        .find(&open)
+        .unwrap_or_else(|| panic!("no `{id}` in:\n{html}"))
+        + open.len();
+    let rest = &html[start..];
+    &rest[..rest.find("</p>").expect("unclosed paragraph")]
+}
+
+#[test]
+fn a_translation_reaches_the_page() {
+    assert_eq!(part(&render("pl-PL"), "translated"), "Zarezerwuj teraz");
+}
+
+#[test]
+fn an_untranslated_string_renders_as_its_own_english() {
+    assert_eq!(
+        part(&render("pl-PL"), "untranslated"),
+        "Nobody has translated this"
+    );
+}
+
+#[test]
+fn the_source_locale_is_what_a_locale_falls_back_to() {
+    // "Sign in" is translated only in en-GB, and to something other than itself —
+    // so English here is the source catalogue's answer rather than the id.
+    assert_eq!(part(&render("pl-PL"), "from-source"), "Log in");
+}
+
+#[test]
+fn context_separates_identical_english() {
+    let html = render("pl-PL");
+    assert_eq!(part(&html, "context-dialog"), "zamknij");
+    assert_eq!(part(&html, "context-distance"), "blisko");
+}
+
+#[test]
+fn cldr_chooses_the_plural_form_and_binds_the_count() {
+    let html = render("pl-PL");
+    assert_eq!(part(&html, "one"), "1 plik");
+    assert_eq!(part(&html, "few"), "2 pliki");
+    assert_eq!(part(&html, "many"), "5 plików");
+}
+
+#[test]
+fn a_value_is_interpolated_into_the_translation() {
+    assert_eq!(part(&render("pl-PL"), "interpolated"), "pokazano 3 z 36");
+}
+
+#[test]
+fn a_translator_moves_the_link_and_code_still_owns_the_href() {
+    assert_eq!(
+        part(&render("pl-PL"), "markup"),
+        r#"mój <a href="/pl-PL/cv">życiorys</a> jest tutaj"#
+    );
+}
+
+#[test]
+fn a_catalogue_cannot_put_markup_on_the_page() {
+    let html = render("pl-PL");
+
+    // Two escapers are in play and they spell an entity differently — Askama's is
+    // numeric, Markup's is named — so these ask what reached the page rather than
+    // which characters it was spelt with.
+    let text = part(&html, "hostile-text");
+    assert!(!text.contains("<script"), "{text}");
+    assert!(text.contains("alert(2)"), "escaped away entirely:\n{text}");
+
+    // `|safe` is not a way round it: Markup escapes everything it was not given a
+    // name for, so a translator's own tags are text.
+    let markup = part(&html, "hostile-markup");
+    assert!(!markup.contains("<img"), "{markup}");
+    assert!(!markup.contains("<b>"), "{markup}");
+    assert!(markup.contains("nie pogrubione"), "{markup}");
+}
+
+#[test]
+fn the_source_locale_renders_the_english_it_was_written_in() {
+    let html = render("en-GB");
+    assert_eq!(part(&html, "translated"), "Book now");
+    assert_eq!(part(&html, "context-dialog"), "close");
+    assert_eq!(part(&html, "many"), "5 files");
+}


### PR DESCRIPTION
Follow-up to #35, which removed the scratch page that was covering this by being served.

The unit tests reach each piece on its own — interpolation, markup, plural selection, lookup. None of them covers the join:

- Askama resolving a bare `__(…)` to the trait method
- a `Message` going *through* the HTML escaper and a `Markup` past it
- a `.po` file on disk being what decides any of it

`crates/askama_gettext/tests/render.rs` renders a fixture template through `Template::render` against two checked-in catalogues, and asserts on the HTML. Nine cases: translation, source-locale fallback, untranslated passthrough, context disambiguation, all three Polish CLDR forms, interpolation, a translator moving a link, and a hostile catalogue reaching neither `{{ }}` nor `|safe`.

## Where things live

The fixture template is `crates/askama_gettext/templates/i18n.html`, not `src/templates/`. Extraction walks the templates a *site* declares, so anything under `src/templates/` becomes strings in all 36 catalogues — which is the mechanism that put `<script>alert(1)</script>` in front of translators in the first place. Askama resolves `path = "i18n.html"` against the crate's own `templates/`, so the fixture is invisible to the site.

Askama is a dev-dependency, not a dependency. The crate is what a template *calls* and never calls Askama itself; rendering one is only how this is checked.

## One thing it turned up

The two escapers spell an entity differently — Askama's is numeric (`&#60;`), `Markup`'s is named (`&lt;`). Both are correct, and no test had ever put them side by side. The escaping assertions ask what reached the page rather than which characters it was spelt with, so they don't pin Askama's internals.

## Verifying

`cargo test -p askama_gettext --test render`, or `task check`.

## Depends on

#33 — `format:check` fails on `main`, so CI here is red until that merges. The only `Diff in` lines are `main`'s three in `merge.rs`.