### PR TITLE
i18n: make serving a fuzzy translation a choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,18 @@ of leaving a slot nobody will translate.
 `task i18n:sync` extracts from the templates into every catalogue and reports what's
 outstanding. Extraction walks Askama's own AST, so it recognises no template syntax
 of its own and can't drift from what Askama accepts. Translations, translator
-comments, flags and header metadata all survive a round trip.
+comments, flags and header metadata all survive a round trip. A message that's left
+the templates is deleted and named in the output, rather than flagged — `fuzzy`
+already means a translation needing review, and an obsolete entry wearing that flag
+is indistinguishable from one a translator set.
+
+Which leaves `fuzzy` meaning only what a translator meant by it, so `FUZZY` in
+`generator/config.rs` decides what to do with one. This site serves them: most of a
+sentence in your own language beats all of one in someone else's. `msgfmt` would do
+the opposite, and that's the right default where a msgid is a key like `nav.close` —
+here it's the English, so both answers are a real sentence and it's a judgement call
+rather than a rule. Set it to `Fuzzy::Skip` to hold a drifted translation back until
+someone reviews it.
 
 ## Assets
 

--- a/crates/askama_gettext/src/catalog.rs
+++ b/crates/askama_gettext/src/catalog.rs
@@ -23,6 +23,27 @@ fn key(context: Option<&str>, msgid: &str) -> String {
     }
 }
 
+/// What to do with a translation a translator has flagged as needing review.
+///
+/// gettext's own tools skip them: `msgfmt` leaves a fuzzy entry out of the compiled
+/// catalogue, so the message falls back. That is the safer default where a msgid is
+/// a key, because it is the difference between a stale sentence and `nav.close` on
+/// the page.
+///
+/// Here a msgid is the English, so both answers render a real sentence and neither
+/// is obviously right — [`Serve`](Self::Serve) shows a reader a translation that may
+/// have drifted, [`Skip`](Self::Skip) shows them a language they may not read. Which
+/// is worse depends on the audience, so it is a choice the caller makes rather than
+/// one this crate makes for them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Fuzzy {
+    /// Use it anyway. A translation that has drifted is usually still closer than
+    /// the source language.
+    Serve,
+    /// Leave it out, as `msgfmt` does, and fall back as if it were untranslated.
+    Skip,
+}
+
 /// One locale's messages.
 pub struct Catalog {
     singular: HashMap<String, String>,
@@ -37,7 +58,7 @@ impl Catalog {
     ///
     /// Fails if the file cannot be parsed, if CLDR has no rules for the locale, or
     /// if the catalogue's `Plural-Forms` disagrees with CLDR — see [`Forms::check`].
-    pub fn load(path: &Path, locale: &str) -> Result<Self> {
+    pub fn load(path: &Path, locale: &str, fuzzy: Fuzzy) -> Result<Self> {
         let parsed = po_file::parse(path).map_err(|e| Error::Catalog {
             path: path.to_owned(),
             message: e.to_string(),
@@ -50,6 +71,12 @@ impl Catalog {
         let mut plural = HashMap::new();
 
         for message in parsed.messages() {
+            // Skipped rather than stored-and-ignored, so a fuzzy message is missing
+            // from the map and falls back the same way an untranslated one does.
+            if fuzzy == Fuzzy::Skip && message.is_fuzzy() {
+                continue;
+            }
+
             let id = key(message.msgctxt(), message.msgid());
 
             if let Ok(translations) = message.msgstr_plural() {
@@ -105,12 +132,12 @@ impl Catalogs {
     /// # Errors
     ///
     /// Fails if any catalogue fails to load.
-    pub fn load(dir: &Path, locales: &[&str], source: &str) -> Result<Self> {
+    pub fn load(dir: &Path, locales: &[&str], source: &str, fuzzy: Fuzzy) -> Result<Self> {
         let mut by_locale = HashMap::new();
 
         for locale in locales {
             let path: PathBuf = dir.join(locale).join("messages.po");
-            by_locale.insert((*locale).to_owned(), Catalog::load(&path, locale)?);
+            by_locale.insert((*locale).to_owned(), Catalog::load(&path, locale, fuzzy)?);
         }
 
         Ok(Self {

--- a/crates/askama_gettext/src/lib.rs
+++ b/crates/askama_gettext/src/lib.rs
@@ -39,7 +39,12 @@
 //! [`extract`] reads those calls back out using Askama's own parser, so it
 //! recognises no template syntax of its own and cannot drift from what Askama
 //! accepts. [`merge`] writes them into `.po` files, keeping existing translations,
-//! comments and flags.
+//! comments and flags, and deleting what has left the templates rather than
+//! flagging it — so `fuzzy` keeps meaning only what a translator meant by it.
+//!
+//! What to then do with one is [`Fuzzy`], which the caller chooses: `msgfmt` skips
+//! them, but where a msgid is the English rather than a key both answers render a
+//! real sentence.
 //!
 //! # Plurals
 //!
@@ -63,7 +68,7 @@ pub mod message;
 pub mod plural;
 pub mod translate;
 
-pub use catalog::{Catalog, Catalogs};
+pub use catalog::{Catalog, Catalogs, Fuzzy};
 pub use error::{Error, Result};
 pub use extract::Message as ExtractedMessage;
 pub use interpolate::interpolate;

--- a/crates/askama_gettext/templates/i18n.html
+++ b/crates/askama_gettext/templates/i18n.html
@@ -7,6 +7,7 @@
 <p id="translated">{{ __("Book now") }}</p>
 <p id="from-source">{{ __("Sign in") }}</p>
 <p id="untranslated">{{ __("Nobody has translated this") }}</p>
+<p id="needs-review">{{ __("This translation needs review") }}</p>
 
 <p id="context-dialog">{{ __p("A button that dismisses a dialog", "close") }}</p>
 <p id="context-distance">{{ __p("How near something is", "close") }}</p>

--- a/crates/askama_gettext/tests/locales/pl-PL/messages.po
+++ b/crates/askama_gettext/tests/locales/pl-PL/messages.po
@@ -10,6 +10,12 @@ msgstr ""
 msgid "Book now"
 msgstr "Zarezerwuj teraz"
 
+# Flagged by a translator, which is the only way the flag arrives — extraction
+# deletes what has left the templates rather than marking it.
+#, fuzzy
+msgid "This translation needs review"
+msgstr "To tłumaczenie wymaga sprawdzenia"
+
 msgctxt "A button that dismisses a dialog"
 msgid "close"
 msgstr "zamknij"

--- a/crates/askama_gettext/tests/render.rs
+++ b/crates/askama_gettext/tests/render.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 
 use askama::Template;
-use askama_gettext::{Catalogs, Translate, Translator};
+use askama_gettext::{Catalogs, Fuzzy, Translate, Translator};
 
 #[derive(Template)]
 #[template(path = "i18n.html")]
@@ -26,8 +26,12 @@ impl Translate for Page<'_> {
 }
 
 fn render(locale: &str) -> String {
+    render_with(locale, Fuzzy::Serve)
+}
+
+fn render_with(locale: &str, fuzzy: Fuzzy) -> String {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/locales");
-    let catalogs = Catalogs::load(&dir, &["en-GB", "pl-PL"], "en-GB").unwrap();
+    let catalogs = Catalogs::load(&dir, &["en-GB", "pl-PL"], "en-GB", fuzzy).unwrap();
 
     Page {
         catalogs: &catalogs,
@@ -60,6 +64,22 @@ fn an_untranslated_string_renders_as_its_own_english() {
         part(&render("pl-PL"), "untranslated"),
         "Nobody has translated this"
     );
+}
+
+#[test]
+fn serving_fuzzy_uses_a_translation_that_may_have_drifted() {
+    assert_eq!(
+        part(&render_with("pl-PL", Fuzzy::Serve), "needs-review"),
+        "To tłumaczenie wymaga sprawdzenia"
+    );
+}
+
+#[test]
+fn skipping_fuzzy_falls_back_as_if_it_were_untranslated() {
+    let html = render_with("pl-PL", Fuzzy::Skip);
+    assert_eq!(part(&html, "needs-review"), "This translation needs review");
+    // Only the flagged one goes; its neighbours in the same catalogue stay.
+    assert_eq!(part(&html, "translated"), "Zarezerwuj teraz");
 }
 
 #[test]

--- a/generator/config.rs
+++ b/generator/config.rs
@@ -5,6 +5,8 @@
 //! `icu_experimental`, and this is data that changes about as often as a language
 //! renames itself. Regenerate with `task i18n:locales`.
 
+use askama_gettext::Fuzzy;
+
 pub struct Locale {
     pub code: &'static str,
     pub name: &'static str,
@@ -13,6 +15,18 @@ pub struct Locale {
 }
 
 pub const SOURCE: &str = "en-GB";
+
+/// What a `fuzzy` translation does here.
+///
+/// `msgfmt` would drop it. This site serves it: the flag means a translation may
+/// have drifted from an English that changed, and most of a sentence in your own
+/// language beats all of one in someone else's. Nothing sets the flag — extraction
+/// deletes what has left the templates rather than marking it — so it only ever
+/// arrives from a translator or from Poedit, and their judgement is not overridden.
+///
+/// Switch to [`Fuzzy::Skip`] to hold a drifted translation back until it is
+/// reviewed, at the cost of showing English in the meantime.
+pub const FUZZY: Fuzzy = Fuzzy::Serve;
 
 pub const LOCALES: &[Locale] = &[
     Locale {

--- a/generator/main.rs
+++ b/generator/main.rs
@@ -11,7 +11,7 @@ use pulldown_cmark::{Options, Parser, html};
 
 use askama_gettext::Catalogs;
 use blit::assets::Assets;
-use blit::config::{LOCALES, SOURCE};
+use blit::config::{FUZZY, LOCALES, SOURCE};
 use blit::routes::{PAGES, url};
 use blit::templates::{Context, Cv, Index, LocaleLink, Urls};
 
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
     let build = root.join(".build");
 
     let codes: Vec<&str> = LOCALES.iter().map(|l| l.code).collect();
-    let catalogs = Catalogs::load(&root.join("src/locales"), &codes, SOURCE)?;
+    let catalogs = Catalogs::load(&root.join("src/locales"), &codes, SOURCE, FUZZY)?;
 
     let mut assets = Assets::load(&root.join("src/static"))?;
 


### PR DESCRIPTION
`Catalog::load` ignored the `fuzzy` flag, so a translation a translator had marked as needing review shipped anyway. `msgfmt` does the opposite and leaves it out of the compiled catalogue.

Neither is right in general, which is why this is a parameter rather than a fix.

Where a msgid is a key, skipping a fuzzy translation means rendering `nav.close` at a reader, so gettext's default is the only sane one. Here a msgid is the English, so both answers put a real sentence on the page — serving shows a translation that may have drifted from an English that changed, skipping shows a language the reader may not have. Which is worse depends on the audience, so `Fuzzy` is a parameter to `Catalog::load` and `Catalogs::load`, and the site states its answer in `generator/config.rs` beside `SOURCE`.

## It stays on Serve

Most of a sentence in your own language beats all of one in someone else's, and this is a personal site rather than a product mid-translation-cycle.

Worth noting what makes that safe now: since #37 stopped marking obsolete messages `fuzzy`, nothing in the codebase sets the flag at all. It can only arrive from a translator or from Poedit. Before #37, honouring it would have silently unshipped every obsolete-marked message — the two changes only work in this order.

## Verifying

Two new render tests cover both settings against the same catalogue, and check that skipping takes only the flagged message rather than its neighbours.

The library tests can't show the const is actually threaded through the generator, so that was checked by hand: flagging `change language` fuzzy in `pl-PL` and building both ways gives `zmień język` under `Serve` and `change language` under `Skip`. Both scratch edits are reverted — `src/locales/` is untouched by this PR.

## Not done

Nothing ever *produces* a fuzzy. Standard `msgmerge` fuzzy-matches a changed msgid against the old translation and flags the result; this merge looks up by exact `(context, id, plural)`, so rewording a string silently drops its translations in all 36 catalogues and the message comes back untranslated rather than flagged for review. That's the bigger hole in the workflow and wants its own change — this one only decides what to do with a flag once it exists.