### PR TITLE
i18n: extract every call shape the trait offers

### DIFF
--- a/crates/askama_gettext/src/extract.rs
+++ b/crates/askama_gettext/src/extract.rs
@@ -1,4 +1,5 @@
-//! Finds `__`, `__p`, `__n` and `__h` calls in Askama templates.
+//! Finds the `__` family — `__`, `__p`, `__n`, `__np` and their `h` variants — in
+//! Askama templates.
 //!
 //! The templates are parsed by Askama's own parser, so this recognises no template
 //! syntax of its own: if Askama's grammar changes, extraction follows rather than
@@ -38,8 +39,8 @@ fn shape(name: &str) -> Option<(bool, bool)> {
         // (takes a context first, takes a plural second)
         "__" | "__h" => Some((false, false)),
         "__p" | "__ph" => Some((true, false)),
-        "__n" => Some((false, true)),
-        "__np" => Some((true, true)),
+        "__n" | "__nh" => Some((false, true)),
+        "__np" | "__nph" => Some((true, true)),
         _ => None,
     }
 }
@@ -278,6 +279,31 @@ mod tests {
         assert_eq!(found[2].plural.as_deref(), Some("%{count} locales"));
         assert_eq!(found[0].line, 1);
         assert_eq!(found[4].line, 5);
+    }
+
+    #[test]
+    fn finds_every_method_the_trait_offers() {
+        // Translate has eight methods and this match has to know all of them: one
+        // it does not recognise renders correctly in the source language and is
+        // never extracted, so it can never be translated.
+        let found = extract(
+            r#"{{ __("a") }}
+{{ __p("ctx", "b") }}
+{{ __n("c", "cs", n) }}
+{{ __np("ctx", "d", "ds", n) }}
+{{ __h("e") }}
+{{ __ph("ctx", "f") }}
+{{ __nh("g", "gs", n) }}
+{{ __nph("ctx", "h", "hs", n) }}"#,
+        );
+
+        let ids: Vec<&str> = found.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, ["a", "b", "c", "d", "e", "f", "g", "h"]);
+
+        // The h variants carry the same context and plural as their plain twins.
+        assert_eq!(found[6].plural.as_deref(), Some("gs"));
+        assert_eq!(found[7].plural.as_deref(), Some("hs"));
+        assert_eq!(found[7].context.as_deref(), Some("ctx"));
     }
 
     #[test]


### PR DESCRIPTION
`Translate` has eight methods. The extractor's `shape` match knew six.

`__nh` and `__nph` — countable *with markup* — fell through to `_ => None`, so a template using either rendered perfectly correct English and put nothing in any catalogue. No error, no warning: the message simply never reached a translator, in all 36 locales, permanently.

Nothing uses them today, so this is a trap rather than a live bug. It would have been found by someone reaching for `__nh` six months from now and quietly concluding the i18n didn't work.

## Why it drifted

The trait and this match are two lists that have to agree, and nothing made them. The new test enumerates all eight call shapes, so adding a ninth method without teaching the extractor about it now fails.

## Verifying

`cargo test -p askama_gettext`. The new test asserts all eight ids extract in order, and that the `h` variants carry the same context and plural as their plain twins.