### PR TITLE
i18n: fall back through the language before the source

### DIFF
--- a/crates/askama_gettext/src/catalog.rs
+++ b/crates/askama_gettext/src/catalog.rs
@@ -152,8 +152,8 @@ impl Catalogs {
         self.by_locale.get(locale)
     }
 
-    /// gettext's `gettext`: the translation, else the source locale's, else the
-    /// English — which the id already is.
+    /// gettext's `gettext`: the translation, else the language's, else the source
+    /// locale's, else the English — which the id already is.
     #[must_use]
     pub fn gettext<'a>(&'a self, locale: &str, msgid: &'a str) -> &'a str {
         self.lookup(locale, None, msgid).unwrap_or(msgid)
@@ -198,15 +198,33 @@ impl Catalogs {
             .unwrap_or(if count == 1 { msgid } else { plural })
     }
 
-    fn lookup(&self, locale: &str, context: Option<&str>, msgid: &str) -> Option<&str> {
-        self.get(locale)
-            .and_then(|catalog| catalog.get(context, msgid))
-            .or_else(|| {
-                self.get(&self.source)
-                    .and_then(|catalog| catalog.get(context, msgid))
-            })
+    /// The catalogues to try, in order: the locale, the language on its own, then
+    /// the source.
+    ///
+    /// `pt-BR` before `pt` before `en-GB` — a catalogue for the whole language is a
+    /// better answer than another language entirely, and a reader of one region's
+    /// dialect can read the other's. A locale set written only as `xx-YY`, which is
+    /// what this site has, never finds the middle step and the chain costs nothing.
+    fn chain<'a>(&'a self, locale: &'a str) -> impl Iterator<Item = &'a str> {
+        let language = locale.split('-').next().unwrap_or(locale);
+
+        [
+            Some(locale),
+            (language != locale).then_some(language),
+            Some(self.source.as_str()),
+        ]
+        .into_iter()
+        .flatten()
     }
 
+    fn lookup(&self, locale: &str, context: Option<&str>, msgid: &str) -> Option<&str> {
+        self.chain(locale)
+            .find_map(|locale| self.get(locale)?.get(context, msgid))
+    }
+
+    // Walks the same chain as the singular: a plural the locale lacks and the source
+    // has was previously ignored, which meant falling all the way back to the two
+    // English forms while a translated set sat in the catalogue next door.
     fn lookup_plural(
         &self,
         locale: &str,
@@ -214,7 +232,7 @@ impl Catalogs {
         msgid: &str,
         count: u64,
     ) -> Option<&str> {
-        self.get(locale)
-            .and_then(|catalog| catalog.get_plural(context, msgid, count))
+        self.chain(locale)
+            .find_map(|locale| self.get(locale)?.get_plural(context, msgid, count))
     }
 }

--- a/crates/askama_gettext/templates/i18n.html
+++ b/crates/askama_gettext/templates/i18n.html
@@ -15,6 +15,7 @@
 <p id="one">{{ __n("%{count} file", "%{count} files", 1) }}</p>
 <p id="few">{{ __n("%{count} file", "%{count} files", 2) }}</p>
 <p id="many">{{ __n("%{count} file", "%{count} files", 5) }}</p>
+<p id="source-plural">{{ __n("%{count} item", "%{count} items", 5) }}</p>
 
 <p id="interpolated">{{ __("showing %{shown} of %{total}").with("shown", 3).with("total", 36) }}</p>
 

--- a/crates/askama_gettext/tests/locales/en-GB/messages.po
+++ b/crates/askama_gettext/tests/locales/en-GB/messages.po
@@ -10,3 +10,10 @@ msgstr ""
 # fall back to that is not simply the id.
 msgid "Sign in"
 msgstr "Log in"
+
+# Countable, and again translated only here — and to something other than the id,
+# so a locale reaching these forms is visibly reading this catalogue.
+msgid "%{count} item"
+msgid_plural "%{count} items"
+msgstr[0] "%{count} thing"
+msgstr[1] "%{count} things"

--- a/crates/askama_gettext/tests/locales/pl/messages.po
+++ b/crates/askama_gettext/tests/locales/pl/messages.po
@@ -1,0 +1,13 @@
+msgid ""
+msgstr ""
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: pl\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
+
+# Translated for the language and not for pl-PL, so a lookup that reaches it has
+# passed through the region and stopped before the source.
+msgid "Nobody has translated this"
+msgstr "Nikt tego nie przetłumaczył"

--- a/crates/askama_gettext/tests/render.rs
+++ b/crates/askama_gettext/tests/render.rs
@@ -82,6 +82,44 @@ fn skipping_fuzzy_falls_back_as_if_it_were_untranslated() {
     assert_eq!(part(&html, "translated"), "Zarezerwuj teraz");
 }
 
+/// The same page with a catalogue for the language sitting between the region and
+/// the source, which is the only way the middle step of the chain exists.
+fn render_through_the_language(locale: &str) -> String {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/locales");
+    let catalogs = Catalogs::load(&dir, &["en-GB", "pl", "pl-PL"], "en-GB", Fuzzy::Serve).unwrap();
+
+    Page {
+        catalogs: &catalogs,
+        locale,
+        cv: "/pl-PL/cv",
+    }
+    .render()
+    .unwrap()
+}
+
+#[test]
+fn the_language_is_tried_before_the_source() {
+    // pl has this and pl-PL does not, so reaching it means the chain stopped at the
+    // language rather than carrying on to English.
+    assert_eq!(
+        part(&render_through_the_language("pl-PL"), "untranslated"),
+        "Nikt tego nie przetłumaczył"
+    );
+
+    // Without a pl catalogue loaded the same lookup passes straight through.
+    assert_eq!(
+        part(&render("pl-PL"), "untranslated"),
+        "Nobody has translated this"
+    );
+}
+
+#[test]
+fn a_plural_falls_back_like_a_singular_does() {
+    // Only en-GB translates this one, and to forms the id does not contain — so
+    // "5 things" is the source catalogue answering rather than the English plural.
+    assert_eq!(part(&render("pl-PL"), "source-plural"), "5 things");
+}
+
 #[test]
 fn the_source_locale_is_what_a_locale_falls_back_to() {
     // "Sign in" is translated only in en-GB, and to something other than itself —


### PR DESCRIPTION
Two holes in the same chain.

## The language was never tried

`lookup` went from the locale straight to the source, so `pt-BR` with nothing of its own reached English while a `pt` catalogue sat unread beside it. It now tries the language subtag in between: `pt-BR` → `pt` → `en-GB` → the id.

A locale set written only as `xx-YY` — which is exactly what this site has — never finds that middle step, so it costs nothing here. It matters for anyone using the crate with a mixed set.

## Plurals walked a shorter chain than singulars

`lookup_plural` didn't fall back to the source **at all**:

```rust
self.get(locale).and_then(|catalog| catalog.get_plural(context, msgid, count))
```

So a countable message the source translated and the locale didn't landed on the raw English `msgid`/`msgid_plural` rather than on the source catalogue's forms — while `gettext`'s doc comment two functions up promised "the translation, else the source locale's". Both now walk the same chain.

## The bit worth checking

Falling back across catalogues means selecting a plural form using the rules of whichever catalogue answered, not the one asked for. That's correct and it's why this is safe: each `Catalog` carries its own `Forms`, so if `en-GB` answers for a Polish page, its two forms are selected with English's rules — because the strings being chosen between are English.

## Verifying

`task check`. Two new tests: one loads a `pl` catalogue between `pl-PL` and the source and asserts the lookup stops at the language, then asserts the same lookup passes through when no `pl` is loaded. The other translates a countable message only in the source, to forms the id doesn't contain, so `5 things` proves the source catalogue answered rather than the English plural.