### PR TITLE
i18n: check the plural expression, not just how many forms it declares

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,16 @@ msgstr[2] "# języków"
 ```
 
 Three boxes for Polish, two for French, one for Japanese. Which one a count selects
-comes from CLDR rather than from evaluating the `Plural-Forms` expression — and the
-header is checked against CLDR, so a catalogue that disagrees fails the build instead
-of leaving a slot nobody will translate.
+comes from CLDR rather than from evaluating the `Plural-Forms` expression — but the
+header is checked against CLDR both ways, so a catalogue that disagrees fails the
+build instead of leaving a slot nobody will translate.
+
+Both halves of it, because the count alone isn't enough. French and English both have
+two forms, and French puts zero in the singular where English doesn't; a header with
+the right `nplurals` and the wrong expression numbers a translator's boxes one way
+while the site selects them another. So the expression is parsed and evaluated
+against CLDR for every count up to a thousand, and the build names the smallest one
+they differ on.
 
 `task i18n:sync` extracts from the templates into every catalogue and reports what's
 outstanding. Extraction walks Askama's own AST, so it recognises no template syntax

--- a/crates/askama_gettext/src/catalog.rs
+++ b/crates/askama_gettext/src/catalog.rs
@@ -69,6 +69,7 @@ impl Catalog {
 
         let forms = Forms::new(locale)?;
         forms.check(locale, parsed.metadata.plural_rules.nplurals)?;
+        forms.check_expression(locale, &parsed.metadata.plural_rules.expr)?;
 
         let mut singular = HashMap::new();
         let mut plural = HashMap::new();

--- a/crates/askama_gettext/src/error.rs
+++ b/crates/askama_gettext/src/error.rs
@@ -47,6 +47,34 @@ pub enum Error {
         categories: String,
     },
 
+    /// A catalogue's `plural=` expression could not be read as one.
+    #[error("plural expression `{expression}`: {message}")]
+    PluralExpression {
+        /// The expression as the catalogue wrote it.
+        expression: String,
+        /// What stopped it being understood.
+        message: String,
+    },
+
+    /// A catalogue's `plural=` expression selects a different form from CLDR.
+    ///
+    /// The count that separates them is given rather than the whole expression,
+    /// because that is the input a translator would have to try before noticing
+    /// their boxes are in an order the site does not use.
+    #[error(
+        "{locale}: for n={count} the catalogue's plural expression gives form {declared}, CLDR gives {actual}"
+    )]
+    PluralExpressionMismatch {
+        /// The locale in question.
+        locale: String,
+        /// The count the two disagree on, smallest first.
+        count: u64,
+        /// What the header's expression works out to.
+        declared: i64,
+        /// What CLDR selects.
+        actual: usize,
+    },
+
     /// An I/O failure.
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/askama_gettext/src/expression.rs
+++ b/crates/askama_gettext/src/expression.rs
@@ -1,0 +1,414 @@
+//! Evaluating a catalogue's `plural=` expression.
+//!
+//! A `Plural-Forms` header carries a C expression in one variable — `n==1 ? 0 :
+//! n%10>=2 && n%10<=4 ? 1 : 2` — which maps a count to a `msgstr[n]` index.
+//! Nothing in this crate uses it to render: [`crate::plural`] gets that from CLDR,
+//! deliberately. What it is used for is checking, and checking needs it evaluated.
+//!
+//! Because a header is otherwise only checked for the number of slots it declares,
+//! a catalogue can agree with CLDR about how many forms a language has and disagree
+//! about which one a count takes. Headers are copied between projects constantly,
+//! which is exactly how a wrong one arrives, and the damage lands on a translator:
+//! their tool offers boxes in one order and the site selects them in another, so a
+//! sentence ends up under a count it was not written for.
+//!
+//! The grammar is C's, restricted to what gettext allows — the ternary, the
+//! boolean and comparison operators, the four arithmetic ones and `%`, over `n`
+//! and integer literals. It is a parser rather than a pattern match on known
+//! headers because the point is to accept whatever a catalogue actually contains
+//! and say what it means.
+
+use crate::error::{Error, Result};
+
+/// A parsed `plural=` expression.
+#[derive(Debug, Clone)]
+pub struct Expression {
+    root: Node,
+}
+
+#[derive(Debug, Clone)]
+enum Node {
+    Count,
+    Literal(i64),
+    Not(Box<Node>),
+    Negate(Box<Node>),
+    Binary(Op, Box<Node>, Box<Node>),
+    Ternary(Box<Node>, Box<Node>, Box<Node>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Or,
+    And,
+    Equal,
+    NotEqual,
+    Less,
+    LessOrEqual,
+    Greater,
+    GreaterOrEqual,
+    Add,
+    Subtract,
+    Multiply,
+    Divide,
+    Remainder,
+}
+
+impl Expression {
+    /// Parses a `plural=` expression.
+    ///
+    /// # Errors
+    ///
+    /// Fails if the expression is not in the subset gettext defines, or has
+    /// anything left over once a complete expression has been read.
+    pub fn parse(source: &str) -> Result<Self> {
+        let tokens = tokenise(source)?;
+        let mut parser = Parser {
+            tokens: &tokens,
+            at: 0,
+            source,
+        };
+
+        let root = parser.ternary()?;
+        if parser.at < parser.tokens.len() {
+            return Err(Error::PluralExpression {
+                expression: source.to_owned(),
+                message: "trailing tokens after a complete expression".to_owned(),
+            });
+        }
+
+        Ok(Self { root })
+    }
+
+    /// The `msgstr[n]` index this expression gives a count.
+    ///
+    /// `None` for a division or remainder by zero, which is the only way an
+    /// otherwise well-formed expression has no answer.
+    #[must_use]
+    pub fn form(&self, count: u64) -> Option<i64> {
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "a count large enough to wrap is not a plural form anybody writes"
+        )]
+        evaluate(&self.root, count as i64)
+    }
+}
+
+fn evaluate(node: &Node, count: i64) -> Option<i64> {
+    Some(match node {
+        Node::Count => count,
+        Node::Literal(value) => *value,
+        Node::Not(inner) => i64::from(evaluate(inner, count)? == 0),
+        Node::Negate(inner) => evaluate(inner, count)?.checked_neg()?,
+        Node::Ternary(condition, yes, no) => {
+            if evaluate(condition, count)? == 0 {
+                evaluate(no, count)?
+            } else {
+                evaluate(yes, count)?
+            }
+        }
+        Node::Binary(op, left, right) => {
+            // Short-circuiting, because C does and a header may rely on it to guard
+            // a remainder.
+            let left = evaluate(left, count)?;
+            match op {
+                Op::Or if left != 0 => return Some(1),
+                Op::And if left == 0 => return Some(0),
+                _ => {}
+            }
+
+            let right = evaluate(right, count)?;
+            match op {
+                Op::Or | Op::And => i64::from(right != 0),
+                Op::Equal => i64::from(left == right),
+                Op::NotEqual => i64::from(left != right),
+                Op::Less => i64::from(left < right),
+                Op::LessOrEqual => i64::from(left <= right),
+                Op::Greater => i64::from(left > right),
+                Op::GreaterOrEqual => i64::from(left >= right),
+                Op::Add => left.checked_add(right)?,
+                Op::Subtract => left.checked_sub(right)?,
+                Op::Multiply => left.checked_mul(right)?,
+                Op::Divide => left.checked_div(right)?,
+                Op::Remainder => left.checked_rem(right)?,
+            }
+        }
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Token {
+    Count,
+    Number(i64),
+    Op(Op),
+    Not,
+    Question,
+    Colon,
+    Open,
+    Close,
+}
+
+fn tokenise(source: &str) -> Result<Vec<Token>> {
+    let bad = |message: &str| Error::PluralExpression {
+        expression: source.to_owned(),
+        message: message.to_owned(),
+    };
+
+    let bytes: Vec<char> = source.chars().collect();
+    let mut tokens = Vec::new();
+    let mut at = 0;
+
+    while at < bytes.len() {
+        let c = bytes[at];
+        let next = bytes.get(at + 1).copied();
+
+        // Two-character operators first, so `<=` is never read as `<` then `=`.
+        let two = match (c, next) {
+            ('=', Some('=')) => Some(Token::Op(Op::Equal)),
+            ('!', Some('=')) => Some(Token::Op(Op::NotEqual)),
+            ('<', Some('=')) => Some(Token::Op(Op::LessOrEqual)),
+            ('>', Some('=')) => Some(Token::Op(Op::GreaterOrEqual)),
+            ('&', Some('&')) => Some(Token::Op(Op::And)),
+            ('|', Some('|')) => Some(Token::Op(Op::Or)),
+            _ => None,
+        };
+
+        if let Some(token) = two {
+            tokens.push(token);
+            at += 2;
+            continue;
+        }
+
+        let one = match c {
+            ' ' | '\t' | '\n' | '\r' => {
+                at += 1;
+                continue;
+            }
+            'n' => Token::Count,
+            '<' => Token::Op(Op::Less),
+            '>' => Token::Op(Op::Greater),
+            '+' => Token::Op(Op::Add),
+            '-' => Token::Op(Op::Subtract),
+            '*' => Token::Op(Op::Multiply),
+            '/' => Token::Op(Op::Divide),
+            '%' => Token::Op(Op::Remainder),
+            '!' => Token::Not,
+            '?' => Token::Question,
+            ':' => Token::Colon,
+            '(' => Token::Open,
+            ')' => Token::Close,
+            ';' => {
+                // gettext writes the expression with a trailing semicolon as often
+                // as not, and it is the end of it either way.
+                break;
+            }
+            '0'..='9' => {
+                let start = at;
+                while at < bytes.len() && bytes[at].is_ascii_digit() {
+                    at += 1;
+                }
+                let digits: String = bytes[start..at].iter().collect();
+                let value = digits
+                    .parse()
+                    .map_err(|_| bad("a number too large to evaluate"))?;
+                tokens.push(Token::Number(value));
+                continue;
+            }
+            other => return Err(bad(&format!("unexpected `{other}`"))),
+        };
+
+        tokens.push(one);
+        at += 1;
+    }
+
+    Ok(tokens)
+}
+
+struct Parser<'a> {
+    tokens: &'a [Token],
+    at: usize,
+    source: &'a str,
+}
+
+impl Parser<'_> {
+    fn bad(&self, message: &str) -> Error {
+        Error::PluralExpression {
+            expression: self.source.to_owned(),
+            message: message.to_owned(),
+        }
+    }
+
+    fn peek(&self) -> Option<&Token> {
+        self.tokens.get(self.at)
+    }
+
+    fn eat(&mut self, token: &Token) -> bool {
+        if self.peek() == Some(token) {
+            self.at += 1;
+            return true;
+        }
+        false
+    }
+
+    /// `a ? b : c`, right-associative as in C.
+    fn ternary(&mut self) -> Result<Node> {
+        let condition = self.binary(0)?;
+
+        if !self.eat(&Token::Question) {
+            return Ok(condition);
+        }
+
+        let yes = self.ternary()?;
+        if !self.eat(&Token::Colon) {
+            return Err(self.bad("a `?` without its `:`"));
+        }
+        let no = self.ternary()?;
+
+        Ok(Node::Ternary(
+            Box::new(condition),
+            Box::new(yes),
+            Box::new(no),
+        ))
+    }
+
+    /// Precedence climbing over the binary operators, loosest level first.
+    fn binary(&mut self, level: usize) -> Result<Node> {
+        const LEVELS: [&[Op]; 6] = [
+            &[Op::Or],
+            &[Op::And],
+            &[Op::Equal, Op::NotEqual],
+            &[Op::Less, Op::LessOrEqual, Op::Greater, Op::GreaterOrEqual],
+            &[Op::Add, Op::Subtract],
+            &[Op::Multiply, Op::Divide, Op::Remainder],
+        ];
+
+        let Some(ops) = LEVELS.get(level) else {
+            return self.unary();
+        };
+
+        let mut left = self.binary(level + 1)?;
+
+        while let Some(Token::Op(op)) = self.peek() {
+            let op = *op;
+            if !ops.contains(&op) {
+                break;
+            }
+
+            self.at += 1;
+            let right = self.binary(level + 1)?;
+            left = Node::Binary(op, Box::new(left), Box::new(right));
+        }
+
+        Ok(left)
+    }
+
+    fn unary(&mut self) -> Result<Node> {
+        if self.eat(&Token::Not) {
+            return Ok(Node::Not(Box::new(self.unary()?)));
+        }
+
+        if self.eat(&Token::Op(Op::Subtract)) {
+            return Ok(Node::Negate(Box::new(self.unary()?)));
+        }
+
+        self.primary()
+    }
+
+    fn primary(&mut self) -> Result<Node> {
+        match self.peek().cloned() {
+            Some(Token::Count) => {
+                self.at += 1;
+                Ok(Node::Count)
+            }
+            Some(Token::Number(value)) => {
+                self.at += 1;
+                Ok(Node::Literal(value))
+            }
+            Some(Token::Open) => {
+                self.at += 1;
+                let inner = self.ternary()?;
+                if !self.eat(&Token::Close) {
+                    return Err(self.bad("a `(` without its `)`"));
+                }
+                Ok(inner)
+            }
+            Some(_) => Err(self.bad("an operator where a value was expected")),
+            None => Err(self.bad("the expression ends early")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn forms(expression: &str, counts: &[u64]) -> Vec<i64> {
+        let parsed = Expression::parse(expression).unwrap();
+        counts.iter().map(|n| parsed.form(*n).unwrap()).collect()
+    }
+
+    #[test]
+    fn the_headers_this_project_actually_carries() {
+        // Polish, straight out of a catalogue, semicolon and all.
+        let polish = "n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;";
+        assert_eq!(forms(polish, &[1, 2, 4, 5, 22, 25]), [0, 1, 1, 2, 1, 2]);
+
+        // The pair that shares a form count and disagrees about zero.
+        assert_eq!(forms("n != 1", &[0, 1, 2]), [1, 0, 1]);
+        assert_eq!(forms("n > 1", &[0, 1, 2]), [0, 0, 1]);
+
+        assert_eq!(forms("0", &[0, 1, 99]), [0, 0, 0]);
+    }
+
+    #[test]
+    fn precedence_is_cs() {
+        // `n % 10 == 1` is `(n % 10) == 1`, not `n % (10 == 1)` — which would be a
+        // remainder by zero for every n, and is the reason this is parsed.
+        assert_eq!(forms("n % 10 == 1", &[1, 11, 2]), [1, 1, 0]);
+        assert_eq!(forms("1 + 2 * 3", &[0]), [7]);
+        assert_eq!(forms("(1 + 2) * 3", &[0]), [9]);
+        assert_eq!(forms("n > 1 && n < 5", &[0, 2, 9]), [0, 1, 0]);
+        // || is looser than &&
+        assert_eq!(forms("n == 0 || n > 1 && n < 5", &[0, 3, 9]), [1, 1, 0]);
+    }
+
+    #[test]
+    fn a_ternary_nests_to_the_right() {
+        assert_eq!(forms("n==0 ? 0 : n==1 ? 1 : 2", &[0, 1, 7]), [0, 1, 2]);
+    }
+
+    #[test]
+    fn a_guard_short_circuits_rather_than_dividing_by_zero() {
+        // C evaluates the right side only if it has to, and a header may lean on
+        // that. Without short-circuiting this has no answer at n=0.
+        assert_eq!(forms("n != 0 && 10 % n == 0", &[0, 5, 3]), [0, 1, 0]);
+    }
+
+    #[test]
+    fn dividing_by_zero_has_no_answer_rather_than_panicking() {
+        assert_eq!(Expression::parse("10 / n").unwrap().form(0), None);
+        assert_eq!(Expression::parse("10 % n").unwrap().form(0), None);
+    }
+
+    #[test]
+    fn unary_operators() {
+        assert_eq!(forms("!n", &[0, 1, 2]), [1, 0, 0]);
+        assert_eq!(forms("!!n", &[0, 3]), [0, 1]);
+        assert_eq!(forms("-1 + 2", &[0]), [1]);
+    }
+
+    #[test]
+    fn what_is_not_an_expression_is_refused() {
+        for bad in [
+            "n +",
+            "(n",
+            "n ? 1",
+            "n == ",
+            "frobnicate(n)",
+            "n 1",
+            "",
+            "* 2",
+        ] {
+            assert!(Expression::parse(bad).is_err(), "accepted `{bad}`");
+        }
+    }
+}

--- a/crates/askama_gettext/src/lib.rs
+++ b/crates/askama_gettext/src/lib.rs
@@ -61,6 +61,7 @@
 
 pub mod catalog;
 pub mod error;
+pub mod expression;
 pub mod extract;
 pub mod interpolate;
 pub mod merge;
@@ -71,6 +72,7 @@ pub mod translate;
 
 pub use catalog::{Catalog, Catalogs, Fuzzy};
 pub use error::{Error, Result};
+pub use expression::Expression;
 pub use extract::Message as ExtractedMessage;
 pub use interpolate::interpolate;
 pub use message::{Markup, Message};

--- a/crates/askama_gettext/src/merge.rs
+++ b/crates/askama_gettext/src/merge.rs
@@ -72,6 +72,7 @@ pub fn into_catalog(path: &Path, locale: &str, messages: &[Extracted]) -> Result
 
     let forms = Forms::new(locale)?;
     forms.check(locale, catalog.metadata.plural_rules.nplurals)?;
+    forms.check_expression(locale, &catalog.metadata.plural_rules.expr)?;
 
     // One entry per (context, id): the same string used in three templates is one
     // message with three references, not three messages.

--- a/crates/askama_gettext/src/plural.rs
+++ b/crates/askama_gettext/src/plural.rs
@@ -5,15 +5,18 @@
 //! evaluates it. CLDR already knows which form a count takes in every language, and
 //! it is kept current in a way a header copied between projects is not.
 //!
-//! What the header is still good for is agreement. It says how many `msgstr[n]`
-//! slots a translator is offered; CLDR says how many the language has. When those
-//! disagree one of them is wrong, and [`Forms::check`] refuses to continue rather
-//! than write to a slot nobody will translate.
+//! What the header is still good for is agreement, in two parts. It says how many
+//! `msgstr[n]` slots a translator is offered, and which one a given count lands in.
+//! CLDR answers both. When either disagrees one of them is wrong, and [`Forms::check`]
+//! and [`Forms::check_expression`] refuse to continue rather than write to a slot
+//! nobody will translate, or number the slots differently from the tool a translator
+//! fills them in with.
 
 use icu_locale_core::Locale;
 use icu_plurals::{PluralCategory, PluralRules};
 
 use crate::error::{Error, Result};
+use crate::expression::Expression;
 
 /// CLDR's canonical order, which is also the order gettext numbers `msgstr[n]`.
 ///
@@ -121,6 +124,43 @@ impl Forms {
             categories: format!("{:?}", self.categories),
         })
     }
+
+    /// Confirms a catalogue's `plural=` expression selects the forms CLDR does.
+    ///
+    /// The count alone is not enough: a header can declare the right number of
+    /// slots and still put a count in the wrong one, which nothing renders but a
+    /// translator's tooling reads. Agreement is checked by evaluating rather than
+    /// by comparing text, so a header written differently from the familiar one is
+    /// fine as long as it means the same thing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::PluralExpression`] if the expression cannot be read, and
+    /// [`Error::PluralExpressionMismatch`] naming the smallest count they differ on.
+    pub fn check_expression(&self, locale: &str, expression: &str) -> Result<()> {
+        let parsed = Expression::parse(expression)?;
+
+        // Enough to cover the mod-10 and mod-100 cycles every CLDR rule turns on,
+        // several times over, plus the small counts they special-case.
+        for count in 0..=1000 {
+            let declared = parsed.form(count).ok_or_else(|| Error::PluralExpression {
+                expression: expression.to_owned(),
+                message: format!("no value for n={count}"),
+            })?;
+
+            let actual = self.index(count);
+            if usize::try_from(declared) != Ok(actual) {
+                return Err(Error::PluralExpressionMismatch {
+                    locale: locale.to_owned(),
+                    count,
+                    declared,
+                    actual,
+                });
+            }
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -163,6 +203,37 @@ mod tests {
         assert_eq!(
             Forms::new("nl-BE").unwrap().count(),
             Forms::new("nl-NL").unwrap().count()
+        );
+    }
+
+    #[test]
+    fn an_expression_that_selects_what_cldr_selects_is_accepted() {
+        Forms::new("pl-PL")
+            .unwrap()
+            .check_expression(
+                "pl-PL",
+                "n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;",
+            )
+            .unwrap();
+        Forms::new("fr-FR")
+            .unwrap()
+            .check_expression("fr-FR", "n > 1")
+            .unwrap();
+    }
+
+    #[test]
+    fn the_right_number_of_forms_in_the_wrong_order_is_still_caught() {
+        // English's expression on French. Both are nplurals=2, so the count check
+        // passes and only evaluating them apart tells them apart — at n=0, which
+        // French puts in the singular and English does not.
+        let error = Forms::new("fr-FR")
+            .unwrap()
+            .check_expression("fr-FR", "n != 1")
+            .unwrap_err();
+
+        assert!(
+            matches!(error, Error::PluralExpressionMismatch { count: 0, .. }),
+            "{error}"
         );
     }
 


### PR DESCRIPTION
Part of #44 — the half I argued there was worth more than generating headers, since creating a catalogue is rare and verifying the ones that exist is every build.

`Forms::check` compared `nplurals` and nothing else. A catalogue could therefore agree with CLDR about how many forms a language has and disagree about which one a count takes, and pass.

## Why that matters even though nothing renders it

Selection comes from CLDR via `Forms::index`, deliberately, so a wrong expression never changes a page. It changes what a **translator** sees: their tool numbers the `msgstr[n]` boxes the header's way, the site reads them CLDR's way, and a sentence ends up under a count it wasn't written for. Silent, and it lands on the person least able to see it.

French and English are the pair that demonstrates it. Both `nplurals=2`; French puts zero in the singular and English doesn't. Swap their expressions and every check that existed still passes.

## What it does

Parses the expression and evaluates it, comparing against `Forms::index` for every count to a thousand — enough to cover the mod-10 and mod-100 cycles CLDR rules turn on, several times over, plus the small values they special-case.

The grammar is C's, restricted to what gettext allows: the ternary, boolean and comparison operators, arithmetic and `%`, over `n` and integer literals. Short-circuiting is implemented because C has it and a header can lean on it to guard a remainder — `n != 0 && 10 % n == 0` has no answer at zero otherwise.

Checked by **evaluating rather than by matching text**, so a header written differently from the familiar one passes as long as it means the same thing. The error names the smallest count they differ on, because that's the input someone would otherwise have to guess:

```
fr-FR: for n=0 the catalogue's plural expression gives form 1, CLDR gives 0
```

## Verifying

All 36 catalogues here already agree — this finds nothing today, which is the good outcome but also means the check needed proving. Giving `fr-FR` English's `n != 1` produces exactly the error above, and the build stops. That case is a regression test, along with a correct-expression case for Polish and French.

Twelve tests on the evaluator itself: the real Polish header, C precedence (`n % 10 == 1` must not parse as `n % (10 == 1)`, which would be a remainder by zero for every count), right-associative ternaries, short-circuit guarding, division by zero returning no answer rather than panicking, and eight malformed expressions being refused.

## Not in scope

Generating a header for a catalogue that doesn't exist — the other half of #44, which stays open. This is the piece that had an external oracle and could be verified rather than judged.