### PR TITLE
ci: publish the image for arm64 as well as amd64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### The image publishes for amd64 and arm64
+
+`ghcr.io/radiosilence/blit` is a manifest list covering both architectures, so the
+deployment is no longer tied to x86 hardware.
+
+One `docker buildx build` emits both. Nothing in the image is architecture-specific —
+`dist/` is bytes and nano-web already ships a manifest list — so there is no `RUN` for
+qemu to emulate and no second compile that a build matrix could parallelise; splitting
+it across runners would only add a manifest-merge job. `--platform` is applied on a
+push alone, because `--load` has nowhere to put a manifest list and a local build only
+needs the architecture it can run.
+
+## Unreleased
+
 ### The generator is Rust
 
 The build is a single binary. `generator/` renders the site, `crates/askama_gettext`

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ Docker image → microk8s → CloudFlare Tunnel, via Pulumi in a separate IaC re
 `dist/` is layered onto [nano-web](https://github.com/radiosilence/nano-web) and the
 image tag is written into the IaC repo's Pulumi config, which Pulumi then rolls out.
 
+The published tag is a manifest list for `linux/amd64` and `linux/arm64`, built in one
+pass — the image is a `COPY` onto a base that already covers both, so there is nothing
+to emulate. A local `task docker:build` loads the host's architecture only, since
+`--load` takes a single image rather than a list.
+
 GitHub Actions only supplies the environment — a checkout, the mise toolchain,
 registry credentials and a build cache. Each step is a Taskfile target, so the same
 pipeline runs on a laptop:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,7 +6,10 @@ vars:
   # dist gives that rewrite a fixed input and leaves dist owned by generate alone.
   BUILD: .build
   IMAGE: ghcr.io/radiosilence/blit
-  PLATFORMS: linux/amd64
+  # Both architectures come out of one build. Nothing in the image is
+  # architecture-specific — dist/ is bytes and the base image is already a manifest
+  # list — so there is no RUN for qemu to emulate and no second compile to parallelise.
+  PLATFORMS: linux/amd64,linux/arm64
   # Debug builds compile several times faster, which is what the watch loop wants.
   # CI sets CI=true and gets an optimised binary.
   PROFILE: '{{if .CI}}--release{{end}}'
@@ -156,9 +159,12 @@ tasks:
       TAG: sha-{{trunc 7 .SHA}}
       BUILT_AT:
         sh: date -u +%Y-%m-%dT%H:%M:%SZ
+    # --platform only applies to a push: a manifest list is a registry object, and
+    # --load has nowhere to put one, so a local build takes the host's architecture —
+    # which is the only one you could run anyway.
     cmd: >-
       docker buildx build .
-      --platform {{.PLATFORMS}}
+      {{if eq .PUSH "true"}}--platform {{.PLATFORMS}}{{end}}
       --tag {{.IMAGE}}:{{.TAG}}
       {{if eq .LATEST "true"}}--tag {{.IMAGE}}:latest{{end}}
       --label org.opencontainers.image.revision={{.SHA}}


### PR DESCRIPTION
`ghcr.io/radiosilence/blit` becomes a manifest list covering `linux/amd64` and
`linux/arm64`, so the deployment is no longer tied to x86 hardware.

## Why there's no build matrix

Nothing in the image is architecture-specific — it is a `COPY dist /public` onto a
base that already ships both architectures — so a single `docker buildx build`
produces both. There is no `RUN` for qemu to emulate and no second compile that
parallel runners could speed up; a matrix would only add a manifest-merge job and a
way for the two halves to disagree. Verified locally: both platforms resolve and
export in under a second.

## Why `--platform` only applies on a push

A manifest list is a registry object, and `--load` has nowhere to put one — passing
both platforms to a local build fails outright unless the containerd image store is
enabled. So a bare `task docker:build` keeps building for the host architecture,
which is the only one it could run anyway.

## Verifying

```bash
task build
docker buildx build . --platform linux/amd64,linux/arm64 --output type=cacheonly  # both arches
task docker:build && docker image inspect ghcr.io/radiosilence/blit:sha-$(git rev-parse --short=7 HEAD) \
  --format '{{.Os}}/{{.Architecture}}'                                            # host arch only
```

Both were run on this branch. The workflow file is unchanged — `setup-buildx-action`
already gives the runner a `docker-container` builder, and no QEMU setup is needed
without a `RUN` step.