### PR TITLE
i18n: create a catalogue for a locale that has none

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ while the site selects them another. So the expression is parsed and evaluated
 against CLDR for every count up to a thousand, and the build names the smallest one
 they differ on.
 
+Adding a locale is a line in `generator/config.rs` and `task i18n:sync`, which writes
+the catalogue. The `Plural-Forms` header it needs is found rather than looked up:
+known gettext expressions are offered to CLDR one at a time and the first it confirms
+is kept, so what's written has been checked against the same source that decides
+which form renders. A language none of them fits is an error rather than a guess.
+
 `task i18n:sync` extracts from the templates into every catalogue and reports what's
 outstanding. Extraction walks Askama's own AST, so it recognises no template syntax
 of its own and can't drift from what Askama accepts. Translations, translator

--- a/crates/askama_gettext/src/error.rs
+++ b/crates/askama_gettext/src/error.rs
@@ -75,6 +75,19 @@ pub enum Error {
         actual: usize,
     },
 
+    /// No known gettext expression selects the forms CLDR gives a locale.
+    ///
+    /// Writing an unverified one is the thing this refuses to do, so a locale that
+    /// reaches here needs its expression supplied by hand and added to the
+    /// candidates once something has checked it.
+    #[error("{locale}: no known plural expression matches CLDR's {forms} forms")]
+    NoPluralExpression {
+        /// The locale in question.
+        locale: String,
+        /// How many forms CLDR gives it, for finding a candidate.
+        forms: usize,
+    },
+
     /// An I/O failure.
     #[error(transparent)]
     Io(#[from] std::io::Error),

--- a/crates/askama_gettext/src/merge.rs
+++ b/crates/askama_gettext/src/merge.rs
@@ -314,6 +314,61 @@ impl Departed {
     }
 }
 
+/// Creates an empty catalogue for a locale, with a header CLDR agrees with.
+///
+/// The reason this could not exist before was that a `Plural-Forms` header needs a
+/// C expression and CLDR does not hand one out. It is now found by offering known
+/// gettext expressions and keeping the one CLDR confirms — see
+/// [`Forms::expression`] — so what gets written has been checked rather than
+/// believed. A locale no candidate fits is an error, not an approximation.
+///
+/// Does nothing if the file already exists, so it is safe to call before a merge.
+///
+/// # Errors
+///
+/// Fails if CLDR has no rules for the locale, if no known expression matches them,
+/// or if the file cannot be written.
+pub fn create_catalog(path: &Path, locale: &str) -> Result<bool> {
+    if path.exists() {
+        return Ok(false);
+    }
+
+    let forms = Forms::new(locale)?;
+    let expression = forms.expression(locale)?;
+
+    // Written as text because a new catalogue is nothing but its header, and the
+    // one field that matters is the one polib does not expose a way to build.
+    let header = format!(
+        "msgid \"\"\nmsgstr \"\"\n\
+         \"MIME-Version: 1.0\\n\"\n\
+         \"Content-Type: text/plain; charset=utf-8\\n\"\n\
+         \"Content-Transfer-Encoding: 8bit\\n\"\n\
+         \"Language: {locale}\\n\"\n\
+         \"Plural-Forms: nplurals={}; plural={expression};\\n\"\n",
+        forms.count(),
+    );
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let temporary = path.with_extension("po.tmp");
+    std::fs::write(&temporary, header)?;
+
+    // Read back before it is put in place: what was written has to be a catalogue
+    // this crate would accept, and the cheapest way to know is to accept it.
+    let written = po_file::parse(&temporary).map_err(|e| Error::Catalog {
+        path: temporary.clone(),
+        message: e.to_string(),
+    })?;
+    forms.check(locale, written.metadata.plural_rules.nplurals)?;
+    forms.check_expression(locale, &written.metadata.plural_rules.expr)?;
+
+    std::fs::rename(&temporary, path)?;
+
+    Ok(true)
+}
+
 /// Writes through a temporary file and renames it into place.
 ///
 /// A catalogue is a translator's work, and writing it in place means truncating it
@@ -424,6 +479,44 @@ mod tests {
         // The header is metadata rather than a message, and must not be swept up
         // with them — without it a catalogue has no Plural-Forms to check.
         assert!(after.contains("Plural-Forms:"), "header lost:\n{after}");
+    }
+
+    #[test]
+    fn a_created_catalogue_is_one_this_crate_would_accept() {
+        for locale in ["fr-FR", "en-GB", "pl-PL", "ar-EG", "ja-JP", "uk-UA"] {
+            let path = std::env::temp_dir().join(format!("agt-created-{locale}.po"));
+            let _ = std::fs::remove_file(&path);
+
+            assert!(create_catalog(&path, locale).unwrap(), "{locale}");
+
+            // The point of the exercise: a header nothing had to be told.
+            let forms = Forms::new(locale).unwrap();
+            let written = po_file::parse(&path).unwrap();
+            forms
+                .check(locale, written.metadata.plural_rules.nplurals)
+                .unwrap();
+            forms
+                .check_expression(locale, &written.metadata.plural_rules.expr)
+                .unwrap();
+
+            // And a merge into it works, which is the reason to have one.
+            let summary = into_catalog(&path, locale, &[site("hello", None)]).unwrap();
+            assert_eq!(summary.total, 1);
+            assert_eq!(summary.untranslated, 1);
+
+            std::fs::remove_file(&path).unwrap();
+        }
+    }
+
+    #[test]
+    fn an_existing_catalogue_is_left_alone() {
+        let path = catalogue(
+            "an_existing_catalogue_is_left_alone",
+            &format!("{PL_HEADER}\n#: t.html:1\nmsgid \"here\"\nmsgstr \"tutaj\"\n"),
+        );
+
+        assert!(!create_catalog(&path, "pl-PL").unwrap());
+        assert!(std::fs::read_to_string(&path).unwrap().contains("tutaj"));
     }
 
     #[test]

--- a/crates/askama_gettext/src/plural.rs
+++ b/crates/askama_gettext/src/plural.rs
@@ -46,6 +46,34 @@ const CANONICAL: [PluralCategory; 6] = [
 /// see [`Forms::index`].
 const COUNTED: std::ops::RangeInclusive<u64> = 0..=200;
 
+/// Expressions gettext tooling already understands, offered rather than trusted.
+///
+/// This is not a table keyed by language, which would be wrong — English and French
+/// share a form count and a category set and need different expressions. Nothing
+/// here is indexed by anything. Each is tried against CLDR for the locale in hand
+/// and kept only if it selects the same form for every count checked, so a wrong
+/// guess in this list cannot become a wrong header. That is what makes it safe to
+/// write down expressions copied from thirty years of `.po` files.
+///
+/// Ordered simplest first, so a language that several fit gets the plainest one.
+const CANDIDATES: &[&str] = &[
+    "0",
+    "n != 1",
+    "n > 1",
+    "n==1 ? 0 : n==2 ? 1 : 2",
+    "n==1 ? 0 : n>=2 && n<=4 ? 1 : 2",
+    "n==1 ? 0 : n==0 || (n%100 > 0 && n%100 < 20) ? 1 : 2",
+    "n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2",
+    "n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2",
+    "n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2",
+    "n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2",
+    "n==1 ? 0 : n==2 ? 1 : n != 8 && n != 11 ? 2 : 3",
+    "n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3",
+    "n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4",
+    "n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5",
+    "n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n==3 ? 3 : n==6 ? 4 : 5",
+];
+
 /// The plural categories a whole number can land in, in CLDR order.
 ///
 /// The position of a category in this list is its `msgstr[n]` index, which is what
@@ -126,6 +154,27 @@ impl Forms {
         slot(category)
             .or_else(|| slot(PluralCategory::Other))
             .unwrap_or(0)
+    }
+
+    /// A `plural=` expression that selects the forms CLDR does.
+    ///
+    /// Found by trying [`CANDIDATES`] and keeping the first CLDR confirms, so the
+    /// answer is verified rather than looked up. A language none of them fits is an
+    /// error: writing an expression that has not been checked is the one thing this
+    /// is here to avoid.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NoPluralExpression`] when no candidate agrees.
+    pub fn expression(&self, locale: &str) -> Result<&'static str> {
+        CANDIDATES
+            .iter()
+            .copied()
+            .find(|candidate| self.check_expression(locale, candidate).is_ok())
+            .ok_or_else(|| Error::NoPluralExpression {
+                locale: locale.to_owned(),
+                forms: self.count(),
+            })
     }
 
     /// Confirms a catalogue's declared `nplurals` matches CLDR.

--- a/generator/bin/i18n.rs
+++ b/generator/bin/i18n.rs
@@ -38,6 +38,7 @@ fn main() -> Result<()> {
 
     // Which locales a removal touched, rather than a line per locale: the templates
     // decide what goes, so the same ids leave all 36 catalogues at once.
+    let mut created: Vec<&str> = Vec::new();
     let mut removed: BTreeMap<String, usize> = BTreeMap::new();
     let mut reworded: BTreeMap<(String, String), usize> = BTreeMap::new();
 
@@ -46,6 +47,14 @@ fn main() -> Result<()> {
             .join("src/locales")
             .join(locale.code)
             .join("messages.po");
+        // A locale added to config.rs has no catalogue until something writes one,
+        // and the header it needs is derivable, so adding a locale is one step.
+        if merge::create_catalog(&path, locale.code)
+            .with_context(|| format!("creating {}", path.display()))?
+        {
+            created.push(locale.code);
+        }
+
         let summary = merge::into_catalog(&path, locale.code, &messages)
             .with_context(|| format!("merging into {}", path.display()))?;
 
@@ -62,6 +71,10 @@ fn main() -> Result<()> {
         } else if summary.untranslated > 0 {
             println!("  {} — {} untranslated", locale.code, summary.untranslated);
         }
+    }
+
+    if !created.is_empty() {
+        println!("\ncatalogues created: {}", created.join(", "));
     }
 
     // Both loud, because between them they are everything extraction does to a


### PR DESCRIPTION
Closes #44.

Adding a locale meant hand-writing a `Plural-Forms` header. CLDR describes plurals as categories and gettext wants a C expression, and nothing converts one to the other — `icu_plurals` exposes the categories, not the rules.

## Offered, not looked up

Now that #46 can evaluate an expression, it doesn't have to be trusted. Known gettext expressions are offered to CLDR one at a time, and the first that selects the same form for every count checked is kept.

This is the distinction #44 turned on. It is **not** a table keyed by language or by category set — that approach is wrong, because English and French share a form count and a category set and need different expressions. Nothing here is indexed by anything. A wrong entry in the candidate list cannot become a wrong header; it simply never matches. That's what makes it safe to write down expressions copied from thirty years of `.po` files.

All 36 locales get one, and it derives the trap correctly from first principles:

```
en-GB  2  -> n != 1
fr-FR  2  -> n > 1
pl-PL  3  -> n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2
ar-EG  6  -> n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : ...
```

For comparison, `msginit` emits no header at all for 24 of those 36.

## Refusing is a feature

A locale no candidate fits errors, naming the locale and how many forms CLDR gives it. Welsh does exactly that — CLDR gives it six, gettext's own table says four — which is how the candidate list gained a six-form entry, rather than by someone guessing one.

## What is written is checked

The header is written to a temporary file, read back with polib, and put through `Forms::check` and `Forms::check_expression` — the same checks a catalogue faces on load — before being renamed into place. A file this creates is one this crate accepts by construction, not by assertion.

## Verifying

`task check`. Tests create catalogues for six locales spanning one to six forms, confirm each passes both checks, and merge into them.

End to end: adding `cy-GB` to `generator/config.rs` and running `task i18n:sync` first produced

```
cy-GB: no known plural expression matches CLDR's 6 forms
```

and after the six-form candidate was added, wrote a correct catalogue and reported `catalogues created: cy-GB`. Both scratch edits are reverted — `generator/config.rs` and `src/locales/` are untouched by this PR.